### PR TITLE
Ingest pipeline integration - creating derived dataset - zhou

### DIFF
--- a/src/ingest-api/app.py
+++ b/src/ingest-api/app.py
@@ -247,6 +247,56 @@ def get_dataset(identifier):
             if conn.get_driver().closed() == False:
                 conn.close()
 
+
+###############################
+@app.route('/datasets/derived', methods=['POST'])
+@secured(groups="HuBMAP-read")
+def create_derived_dataset():
+    if not request.is_json:
+        abort(400, jsonify( { 'error': 'This request requries a json in the body' } ))
+    
+    json_data = request.get_json()
+    pprint(json_data)
+
+    if 'source_dataset_uuid' not in json_data:
+        abort(400, jsonify( { 'error': "The 'source_dataset_uuid' property is requried in the json data from the request" } ))
+
+    # Create a new derived dataset based on this parent dataset ID
+    conn = None
+
+    # try:
+    conn = Neo4jConnection(app.config['NEO4J_SERVER'], app.config['NEO4J_USERNAME'], app.config['NEO4J_PASSWORD'])
+    driver = conn.get_driver()
+    dataset = Dataset(app.config)
+
+    # Note: the user who can create the derived dataset doesn't have to be the same person who created the source dataset
+    # Get the nexus token from request headers
+    nexus_token = None
+    try:
+        nexus_token = AuthHelper.parseAuthorizationTokens(request.headers)
+    except:
+        raise ValueError("Unable to parse globus token from request header")
+
+    pprint("========calling create_derived_datastage()===========")
+    new_record = dataset.create_derived_datastage(driver, nexus_token, json_data)
+    conn.close()
+
+    return jsonify( new_record ), 201
+    # except:
+    #     pprint("========error calling create_derived_datastage()===========")
+    #     msg = 'An error occurred: '
+    #     for x in sys.exc_info():
+    #         msg += str(x)
+    #     abort(400, msg)
+    # finally:
+    #     if conn != None:
+    #         if conn.get_driver().closed() == False:
+    #             conn.close()
+
+
+###############################
+
+
 @app.route('/datasets', methods=['POST'])
 #@cross_origin(origins=[app.config['UUID_UI_URL']], methods=['POST', 'GET'])
 @secured(groups="HuBMAP-read")

--- a/src/ingest-api/app.py
+++ b/src/ingest-api/app.py
@@ -271,7 +271,6 @@ def create_derived_dataset():
         abort(400, jsonify( { 'error': 'This request requries a json in the body' } ))
     
     json_data = request.get_json()
-    #pprint(json_data)
 
     if 'source_dataset_uuid' not in json_data:
         abort(400, jsonify( { 'error': "The 'source_dataset_uuid' property is requried in the json data from the request" } ))

--- a/src/ingest-api/app.py
+++ b/src/ingest-api/app.py
@@ -248,7 +248,22 @@ def get_dataset(identifier):
                 conn.close()
 
 
-###############################
+# Create derived dataset
+"""
+Input JSON example:
+{
+"source_dataset_uuid":"e517ce652d3c4f22ace7f21fd64208ac",
+"derived_dataset_name":"Test derived dataset 1",
+"derived_dataset_entity_type":"Dataset"
+}
+
+Output JSON example:
+{
+    "derived_dataset_uuid": "2ecc257c3fd1875be08a12ff654f1264",
+    "group_display_name": "IEC Testing Group",
+    "group_uuid": "5bd084c8-edc2-11e8-802f-0e368f3075e8"
+}
+"""
 @app.route('/datasets/derived', methods=['POST'])
 @secured(groups="HuBMAP-read")
 def create_derived_dataset():
@@ -260,6 +275,12 @@ def create_derived_dataset():
 
     if 'source_dataset_uuid' not in json_data:
         abort(400, jsonify( { 'error': "The 'source_dataset_uuid' property is requried in the json data from the request" } ))
+    
+    if 'derived_dataset_name' not in json_data:
+        abort(400, jsonify( { 'error': "The 'derived_dataset_name' property is requried in the json data from the request" } ))
+
+    if 'derived_dataset_entity_type' not in json_data:
+        abort(400, jsonify( { 'error': "The 'derived_dataset_entity_type' property is requried in the json data from the request" } ))
 
     # Create a new derived dataset based on this parent dataset ID
     conn = None
@@ -290,9 +311,6 @@ def create_derived_dataset():
         if conn != None:
             if conn.get_driver().closed() == False:
                 conn.close()
-
-
-###############################
 
 
 @app.route('/datasets', methods=['POST'])

--- a/src/ingest-api/dataset.py
+++ b/src/ingest-api/dataset.py
@@ -274,9 +274,6 @@ class Dataset(object):
         if 'provenance_group_uuid' in dataset_record:
             source_dataset_provenance_group_uuid = dataset_record['provenance_group_uuid']
 
-        #pprint("========dataset_record===========")
-        #pprint(dataset_record)
-
         # Note: the user who can create the derived dataset doesn't have to be the same person who created the source dataset
         # That's why we need to parase the userinfo again here
         authcache = None
@@ -289,8 +286,6 @@ class Dataset(object):
         userinfo = authcache.getUserInfo(nexus_token, True)
         if userinfo is Response:
             raise ValueError('Cannot authenticate current token via Globus.')
-
-        #pprint(userinfo)
 
         # Decide the provenance group UUID
         provenance_group = None
@@ -516,7 +511,7 @@ class Dataset(object):
                 group_display_name = provenance_group['displayname']
 
                 new_path = make_new_dataset_directory(str(self.confdata['STAGING_ENDPOINT_FILEPATH']), group_display_name, datastage_uuid[HubmapConst.UUID_ATTRIBUTE])
-                new_globus_path = build_globus_url_for_directory(self.confdata['STAGING_ENDPOINT_UUID'], new_path)
+                new_globus_path = build_globus_url_for_directory(transfer_endpoint, new_path)
                 
                 """new_path = self.get_staging_path(group_display_name, datastage_uuid[HubmapConst.UUID_ATTRIBUTE])
                 new_globus_path = os.makedirs(new_path)"""
@@ -1208,47 +1203,3 @@ def convert_dataset_status(raw_status):
         new_status = HubmapConst.DATASET_STATUS_HOLD
     return new_status
 
-
-if __name__ == "__main__":
-    from flask import Flask
-    # Specify the absolute path of the instance folder and use the config file relative to the instance path
-    app = Flask(__name__, instance_path=os.path.join(os.path.abspath(os.path.dirname(__file__)), 'instance'), instance_relative_config=True)
-    app.config.from_pyfile('app.cfg')
-
-    conn = Neo4jConnection(app.config['NEO4J_SERVER'], app.config['NEO4J_USERNAME'], app.config['NEO4J_PASSWORD'])
-    driver = conn.get_driver()
-    
-    C
-    
-    ingest_id_1 = 'eb0d6aa9579ef4af1383ead1ed2412b2'    
-    uuid_1 = dataset.get_metadata_uuid_for_ingest_id(driver, ingest_id_1)
-    print (uuid_1)
-
-    ingest_id_2 = '6feea44e7a6c143f2a9e1cf750abce84'    
-    uuid_2 = dataset.get_metadata_uuid_for_ingest_id(driver, ingest_id_2)
-    print (uuid_2)
-    
-    ingest_id_3 = 'eb0d6aa0000ef4af1383ead1ed2412b2'
-    ingest_id_4 = 'eb0d6aa1111ef4af1383ead1ed2412b2'
-    ingest_id_5 = 'eb0d6aa2222ef4af1383ead1ed2412b2'
-     
-    id_list = [ingest_id_3, ingest_id_4, ingest_id_5]
-    dataset_obj_1 = dataset.get_dataset(driver, 'eb0d6aa9579ef4af1383ead1ed2412b2')
-    pprint(dataset_obj_1)
-
-    dataset_obj_2 = dataset.get_dataset(driver, '6feea44e7a6c143f2a9e1cf750abce84')
-    pprint(dataset_obj_2)
-    
-    json_object_1 = {'ingest_id': ingest_id_1, 'status': 'success', 'message' : 'everything is ok', 'metadata': '{"attr1":"value_1", "attr_2":"value_2"'}
-    
-    json_object_2 = {'ingest_id': ingest_id_2, 'status': 'error', 'message' : 'Error: This is an error message.  Stack trace: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.', 'metadata': '{"attr1":"value_1_failure", "attr_2":"value_2_failure"'}
-    
-    try:
-        for id in id_list:
-            json_object_2['ingest_id'] = id
-            status_obj = dataset.set_ingest_status(driver, json_object_2)
-        #status_obj = dataset.set_ingest_status(driver, json_object_2)
-    except Exception as e:
-        pprint(e)
-
-    conn.close()

--- a/src/ingest-api/dataset.py
+++ b/src/ingest-api/dataset.py
@@ -241,8 +241,7 @@ class Dataset(object):
 
 
 
-# Create derived dataset
-####################
+    # Create derived dataset
     @classmethod
     def create_derived_datastage(self, driver, nexus_token, json_data):
         conn = Neo4jConnection(self.confdata['NEO4J_SERVER'], self.confdata['NEO4J_USERNAME'], self.confdata['NEO4J_PASSWORD'])
@@ -316,7 +315,8 @@ class Dataset(object):
             metadata_userinfo[HubmapConst.PROVENANCE_USER_DISPLAYNAME_ATTRIBUTE] = userinfo['name']
     
         activity_type = HubmapConst.DATASET_CREATE_ACTIVITY_TYPE_CODE
-        entity_type = HubmapConst.DATASET_TYPE_CODE
+        # Use the entity_type from the input JSON
+        entity_type = json_data['derived_dataset_entity_type']
         
         with driver.session() as session:
             # First create a new uuid for this derived dataset
@@ -354,6 +354,9 @@ class Dataset(object):
                 # Create the Entity Metadata node
                 # Don't use None, it'll throw TypeError: 'NoneType' object does not support item assignment
                 metadata_record = {}
+
+                # Use the dataset name from input json
+                metadata_record['name'] = json_data['derived_dataset_name']
 
                 metadata_record[HubmapConst.DATASET_GLOBUS_DIRECTORY_PATH_ATTRIBUTE] = new_globus_path
                 metadata_record[HubmapConst.DATASET_LOCAL_DIRECTORY_PATH_ATTRIBUTE] = new_path
@@ -411,15 +414,6 @@ class Dataset(object):
                 for x in sys.exc_info():
                     print (x)
                 tx.rollback()
-
-########################
-
-
-
-
-
-
-
 
 
 


### PR DESCRIPTION
@jswelling this PR includes:

- added new endpoint and functionalities to handle the creation of derived dataset from a parent dataset.

- the endpoint is a POST to the ingest-api: /datasets/derived

The input requires a globus nexus token (for group access) and the JSON example:
````
{
"source_dataset_uuid":"e517ce652d3c4f22ace7f21fd64208ac",
"derived_dataset_name":"Test derived dataset 1",
"derived_dataset_entity_type":"Dataset"
}
````
and the response JSON:
````
{
    "derived_dataset_uuid": "2ecc257c3fd1875be08a12ff654f1264",
    "group_display_name": "IEC Testing Group",
    "group_uuid": "5bd084c8-edc2-11e8-802f-0e368f3075e8"
}
````