### PR TITLE
Mods to support choice of default ingest pipeline from config

### DIFF
--- a/src/ingest-api/dataset.py
+++ b/src/ingest-api/dataset.py
@@ -838,7 +838,9 @@ class Dataset(object):
                         # take the incoming uuid_type and uppercase it
                         url = self.confdata['INGEST_PIPELINE_URL'] + '/request_ingest'
                         print('sending request_ingest to: ' + url)
-                        r = requests.post(url, json={"submission_id" : "{uuid}".format(uuid=uuid), "process" : "MICROSCOPY.IMS.ALL", "provider": "{group_name}".format(group_name=group_info['displayname'])}, 
+                        r = requests.post(url, json={"submission_id" : "{uuid}".format(uuid=uuid),
+                                                     "process" : self.confdata['INGEST_PIPELINE_DEFAULT_PROCESS'],
+                                                     "provider": "{group_name}".format(group_name=group_info['displayname'])}, 
                                           headers={'Content-Type':'application/json', 'Authorization': 'Bearer {token}'.format(token=current_token )})
                         if r.ok == True:
                             """expect data like this:

--- a/src/ingest-api/instance/app.cfg.example
+++ b/src/ingest-api/instance/app.cfg.example
@@ -44,3 +44,6 @@ GLOBUS_CLIENT_APP_URI = 'http://localhost:8585/'
 INGEST_PIPELINE_URL = 'http://ingest-pipeline:8789/api/hubmap'
 # internal test: INGEST_PIPELINE_URL = 'http://localhost:5005/datasets/submissions'
 
+# Default processing type for ingest pipeline API.
+INGEST_PIPELINE_DEFAULT_PROCESS = 'SCAN.AND.BEGIN.PROCESSING'
+


### PR DESCRIPTION
Mods to dataset.py to allow setting of default ingest-pipeline DAG from the .cfg file.