### PR TITLE
Ingest pipeline integration fix

### DIFF
--- a/src/ingest-api/app.py
+++ b/src/ingest-api/app.py
@@ -282,8 +282,8 @@ def create_derived_dataset():
         abort(400, jsonify( { 'error': "The 'derived_dataset_types' property is requried in the json data from the request" } ))
 
     # Ensure the data types is an array
-    if isinstance(json_data['derived_dataset_types'], dict):
-        abort(400, jsonify( { 'error': "The 'derived_dataset_types' property is requried in the json data from the request" } ))
+    if not isinstance(json_data['derived_dataset_types'], list):
+        abort(400, jsonify( { 'error': "The 'derived_dataset_types' values must be an json array" } ))
 
     # Create a new derived dataset based on this parent dataset ID
     conn = None

--- a/src/ingest-api/app.py
+++ b/src/ingest-api/app.py
@@ -254,7 +254,7 @@ Input JSON example:
 {
 "source_dataset_uuid":"e517ce652d3c4f22ace7f21fd64208ac",
 "derived_dataset_name":"Test derived dataset 1",
-"derived_dataset_entity_type":"Dataset"
+"derived_dataset_datatype":"QX11"
 }
 
 Output JSON example:
@@ -278,8 +278,8 @@ def create_derived_dataset():
     if 'derived_dataset_name' not in json_data:
         abort(400, jsonify( { 'error': "The 'derived_dataset_name' property is requried in the json data from the request" } ))
 
-    if 'derived_dataset_entity_type' not in json_data:
-        abort(400, jsonify( { 'error': "The 'derived_dataset_entity_type' property is requried in the json data from the request" } ))
+    if 'derived_dataset_datatype' not in json_data:
+        abort(400, jsonify( { 'error': "The 'derived_dataset_datatype' property is requried in the json data from the request" } ))
 
     # Create a new derived dataset based on this parent dataset ID
     conn = None

--- a/src/ingest-api/app.py
+++ b/src/ingest-api/app.py
@@ -254,7 +254,7 @@ Input JSON example:
 {
 "source_dataset_uuid":"e517ce652d3c4f22ace7f21fd64208ac",
 "derived_dataset_name":"Test derived dataset 1",
-"derived_dataset_datatype":"QX11"
+"derived_dataset_types":["QX11", "xxx"]
 }
 
 Output JSON example:
@@ -278,8 +278,12 @@ def create_derived_dataset():
     if 'derived_dataset_name' not in json_data:
         abort(400, jsonify( { 'error': "The 'derived_dataset_name' property is requried in the json data from the request" } ))
 
-    if 'derived_dataset_datatype' not in json_data:
-        abort(400, jsonify( { 'error': "The 'derived_dataset_datatype' property is requried in the json data from the request" } ))
+    if 'derived_dataset_types' not in json_data:
+        abort(400, jsonify( { 'error': "The 'derived_dataset_types' property is requried in the json data from the request" } ))
+
+    # Ensure the data types is an array
+    if isinstance(json_data['derived_dataset_types'], dict):
+        abort(400, jsonify( { 'error': "The 'derived_dataset_types' property is requried in the json data from the request" } ))
 
     # Create a new derived dataset based on this parent dataset ID
     conn = None

--- a/src/ingest-api/dataset.py
+++ b/src/ingest-api/dataset.py
@@ -236,11 +236,6 @@ class Dataset(object):
                 raise
 
 
-
-
-
-
-
     # Create derived dataset
     @classmethod
     def create_derived_datastage(self, driver, nexus_token, json_data):
@@ -335,7 +330,6 @@ class Dataset(object):
                                          HubmapConst.ENTITY_TYPE_ATTRIBUTE : entity_type}
                 
                 stmt = Neo4jConnection.get_create_statement(dataset_entity_record, HubmapConst.ENTITY_NODE_NAME, entity_type, True)
-                print('Derived dataset create statement: ' + stmt)
                 tx.run(stmt)
                 
                 # Create directory on file system for for this new derived dataset
@@ -350,9 +344,10 @@ class Dataset(object):
                 metadata_record = {}
 
                 # Use the dataset name from input json
+                # Need to use constant instead of hardcoding later
                 metadata_record['name'] = json_data['derived_dataset_name']
-                # Also use the dataset datatype from input json
-                metadata_record['datatype'] = json_data['derived_dataset_datatype']
+                # Also use the dataset data types array from input json and store as string in metadata attribute
+                metadata_record[HubmapConst.DATA_TYPES_ATTRIBUTE] = json.dumps(json_data['derived_dataset_types'])
 
                 metadata_record[HubmapConst.DATASET_GLOBUS_DIRECTORY_PATH_ATTRIBUTE] = new_globus_path
                 metadata_record[HubmapConst.DATASET_LOCAL_DIRECTORY_PATH_ATTRIBUTE] = new_path

--- a/src/ingest-api/dataset.py
+++ b/src/ingest-api/dataset.py
@@ -310,8 +310,7 @@ class Dataset(object):
             metadata_userinfo[HubmapConst.PROVENANCE_USER_DISPLAYNAME_ATTRIBUTE] = userinfo['name']
     
         activity_type = HubmapConst.DATASET_CREATE_ACTIVITY_TYPE_CODE
-        # Use the entity_type from the input JSON
-        entity_type = json_data['derived_dataset_entity_type']
+        entity_type = HubmapConst.DATASET_TYPE_CODE
         
         with driver.session() as session:
             # First create a new uuid for this derived dataset
@@ -352,6 +351,8 @@ class Dataset(object):
 
                 # Use the dataset name from input json
                 metadata_record['name'] = json_data['derived_dataset_name']
+                # Also use the dataset datatype from input json
+                metadata_record['datatype'] = json_data['derived_dataset_datatype']
 
                 metadata_record[HubmapConst.DATASET_GLOBUS_DIRECTORY_PATH_ATTRIBUTE] = new_globus_path
                 metadata_record[HubmapConst.DATASET_LOCAL_DIRECTORY_PATH_ATTRIBUTE] = new_path


### PR DESCRIPTION
@jswelling this is a fix to the data type from the json input. 

The updated input json looks like:

````
{
"source_dataset_uuid":"e517ce652d3c4f22ace7f21fd64208ac",
"derived_dataset_name":"Test derived dataset 1",
"derived_dataset_types":["QX11", "xxx"]
}
````

Note: the `"derived_dataset_types"` is a json array now. You can pass in only one item if not multiple data types.

Output JSON stays no change:
````
{
    "derived_dataset_uuid": "2ecc257c3fd1875be08a12ff654f1264",
    "group_display_name": "IEC Testing Group",
    "group_uuid": "5bd084c8-edc2-11e8-802f-0e368f3075e8"
}
````

After merging this PR, on your localhost, you'll need to stop and remove the ingest-api container, also delete the ingest-api image. Because some code changes are made in the commons repo, which is a python dependency to the ingest-api.

Then in the gateway, `sudo ./hubmap-docker.sh localhost start` this will create the new image for ingest-api and start the container as well.

Thanks.