### PR TITLE
Docker non root

### DIFF
--- a/docker/docker-compose-ingest-api.dev.yml
+++ b/docker/docker-compose-ingest-api.dev.yml
@@ -9,6 +9,8 @@ services:
     image: ingest-api:1.5
     hostname: ingest-api
     container_name: ingest-api
+    environment:
+      - HOST_UID=1000
     volumes:
       # Mount the source code to container
       - "../src/ingest-api:/usr/src/app/src"

--- a/docker/docker-compose-ingest-api.dev.yml
+++ b/docker/docker-compose-ingest-api.dev.yml
@@ -6,10 +6,11 @@ services:
   ingest-api:
     build: ./ingest-api-dev
     # Build the image with name and tag
-    image: ingest-api:1.5
+    image: ingest-api:1.7
     hostname: ingest-api
     container_name: ingest-api
     environment:
+      - HOST_GID=1000
       - HOST_UID=1000
     volumes:
       # Mount the source code to container

--- a/docker/docker-compose-ingest-api.prod.yml
+++ b/docker/docker-compose-ingest-api.prod.yml
@@ -13,8 +13,10 @@ services:
     restart: always
     # Map host machine port 80, 443 to container ports
     ports:
-      - "80:80"
-      - "443:443"
+      - "80:8080"
+      - "443:8443"
+    environment:
+      - HOST_UID=1000
     volumes:
       # Mount the app config to container in order to keep it outside of the image
       - "../src/ingest-api/instance:/usr/src/app/src/instance"

--- a/docker/docker-compose-ingest-api.prod.yml
+++ b/docker/docker-compose-ingest-api.prod.yml
@@ -16,6 +16,7 @@ services:
       - "80:8080"
       - "443:8443"
     environment:
+      - HOST_GID=1000
       - HOST_UID=1000
     volumes:
       # Mount the app config to container in order to keep it outside of the image

--- a/docker/docker-compose-ingest-api.test.yml
+++ b/docker/docker-compose-ingest-api.test.yml
@@ -13,8 +13,10 @@ services:
     restart: always
     # Map host machine port 80, 443 to container ports
     ports:
-      - "80:80"
-      - "443:443"
+      - "80:8080"
+      - "443:8443"
+    environment:
+      - HOST_UID=1000
     volumes:
       # Mount the app config to container in order to keep it outside of the image
       - "../src/ingest-api/instance:/usr/src/app/src/instance"

--- a/docker/docker-compose-ingest-api.test.yml
+++ b/docker/docker-compose-ingest-api.test.yml
@@ -16,6 +16,7 @@ services:
       - "80:8080"
       - "443:8443"
     environment:
+      - HOST_GID=1000
       - HOST_UID=1000
     volumes:
       # Mount the app config to container in order to keep it outside of the image

--- a/docker/docker-compose-ingest-ui.dev.yml
+++ b/docker/docker-compose-ingest-ui.dev.yml
@@ -6,9 +6,12 @@ services:
   ingest-ui:
     build: ./ingest-ui
     # Build the image with name and tag
-    image: ingest-ui:1.5
+    image: ingest-ui:1.7
     hostname: ingest-ui
     container_name: ingest-ui
+    environment:
+      - HOST_GID=1000
+      - HOST_UID=1000
     volumes:
       # Mount the logging to container
       - "../log:/usr/src/app/log"

--- a/docker/docker-compose-ingest-ui.prod.yml
+++ b/docker/docker-compose-ingest-ui.prod.yml
@@ -6,9 +6,12 @@ services:
   ingest-ui:
     build: ./ingest-ui
     # Build the image with name and tag
-    image: ingest-ui:1.5
+    image: ingest-ui:1.7
     hostname: ingest-ui
     container_name: ingest-ui
+    environment:
+      - HOST_GID=1000
+      - HOST_UID=1000
     init: true
     restart: always
     volumes:

--- a/docker/docker-compose-ingest-ui.test.yml
+++ b/docker/docker-compose-ingest-ui.test.yml
@@ -6,9 +6,12 @@ services:
   ingest-ui:
     build: ./ingest-ui
     # Build the image with name and tag
-    image: ingest-ui:1.5
+    image: ingest-ui:1.7
     hostname: ingest-ui
     container_name: ingest-ui
+    environment:
+      - HOST_GID=1000
+      - HOST_UID=1000
     init: true
     restart: always
     volumes:

--- a/docker/ingest-api-dev/Dockerfile
+++ b/docker/ingest-api-dev/Dockerfile
@@ -17,5 +17,11 @@ RUN pip install -r src/requirements.txt
 # EXPOSE does not make the ports of the container accessible to the host.
 EXPOSE 5000
 
+# Set an entrypoint
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+
 # Finally, we run uWSGI with the ini file
 CMD [ "uwsgi", "--ini", "/usr/src/app/src/uwsgi.ini" ]

--- a/docker/ingest-api-dev/Dockerfile
+++ b/docker/ingest-api-dev/Dockerfile
@@ -1,8 +1,7 @@
 # Parent image
 FROM hubmap/api-base-image:latest
 
-LABEL description="HuBMAP Ingest API Service" \
-	version="1.5"
+LABEL description="HuBMAP Ingest API Service"
 
 # Change to directory that contains the Dockerfile
 WORKDIR /usr/src/app

--- a/docker/ingest-api-dev/entrypoint.sh
+++ b/docker/ingest-api-dev/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Pass the HOST_UID from an environment variable specified in the child image docker-compose,
+# defaulting to 9000 if it doesn't exist
+HOST_UID=${HOST_UID:-9000}
+
+echo "Starting ingest-api container with the same host UID: $HOST_UID"
+
+# Create a new user with the same host UID to run processes on container
+# The Filesystem doesn't really care what the user is called,
+# it only cares about the UID attached to that user
+useradd -r -u $HOST_UID -o -c "" -m hubmap
+
+# Lastly we use gosu to execute our process "$@" as that user
+# Remember CMD from a Dockerfile of child image gets passed to the entrypoint.sh as command line arguments
+# "$@" is a shell variable that means "all the arguments"
+exec /usr/local/bin/gosu hubmap "$@"

--- a/docker/ingest-api-prod/Dockerfile
+++ b/docker/ingest-api-prod/Dockerfile
@@ -35,4 +35,10 @@ RUN yum install -y nginx && \
 # Here 5000 is for the uwsgi socket, 80 for nginx
 EXPOSE 5000 80
 
+# Set an entrypoint
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+
 CMD ["./start.sh"]

--- a/docker/ingest-api-prod/Dockerfile
+++ b/docker/ingest-api-prod/Dockerfile
@@ -1,8 +1,7 @@
 # Parent image
 FROM hubmap/api-base-image:latest
 
-LABEL description="HuBMAP Ingest API Service" \
-	version="1.5"
+LABEL description="HuBMAP Ingest API Service"
 
 # Change to directory that contains the Dockerfile
 WORKDIR /usr/src/app
@@ -21,11 +20,13 @@ enabled=1\n'\
 # Reduce the number of layers in image by minimizing the number of separate RUN commands
 # 1 - Install nginx (using the custom yum repo specified earlier)
 # 2 - Remove the default nginx config file
-# 3 - Install flask app dependencies with pip (pip3 also works)
-# 4 - Make the start script executable
-# 5 - Clean all yum cache
+# 3 - Overwrite the nginx.conf with ours to run nginx as non-root
+# 4 - Install flask app dependencies with pip (pip3 also works)
+# 5 - Make the start script executable
+# 6 - Clean all yum cache
 RUN yum install -y nginx && \
     rm /etc/nginx/conf.d/default.conf && \
+    mv nginx.conf /etc/nginx/nginx.conf && \
     pip install -r src/requirements.txt && \
     chmod +x start.sh && \
     yum clean all 

--- a/docker/ingest-api-prod/entrypoint.sh
+++ b/docker/ingest-api-prod/entrypoint.sh
@@ -1,24 +1,31 @@
 #!/bin/bash
 
-# Pass the HOST_UID from an environment variable specified in the child image docker-compose,
+# Pass the HOST_UID and HOST_UID from environment variables specified in the child image docker-compose,
 # defaulting to 9000 if it doesn't exist
+HOST_GID=${HOST_GID:-9000}
 HOST_UID=${HOST_UID:-9000}
 
-echo "Starting ingest-api container with the same host UID: $HOST_UID"
+echo "Starting ingest-api container with the same host user UID: $HOST_UID and GID: $HOST_GID"
 
 # Create a new user with the same host UID to run processes on container
 # The Filesystem doesn't really care what the user is called,
 # it only cares about the UID attached to that user
-useradd -r -u $HOST_UID -o -c "" -m hubmap
+# Check if user already exists and don't recreate across container restarts
+getent passwd $HOST_UID > /dev/null 2&>1
+# $? is a special variable that captures the exit status of last task
+if [ $? -ne 0 ]; then
+    groupadd -r -g $HOST_GID hubmap
+    useradd -r -u $HOST_UID -g $HOST_GID -m hubmap
+fi
 
 # When running Nginx as a non-root user, we need to create the pid file
 # and give read and write access to /var/run/nginx.pid, /var/cache/nginx, and /var/log/nginx
 # In individual nginx *.conf, also don't listen on ports 80 or 443 because 
 # only root processes can listen to ports below 1024
 touch /var/run/nginx.pid
-chown -R hubmap /var/run/nginx.pid
-chown -R hubmap /var/cache/nginx
-chown -R hubmap /var/log/nginx
+chown -R hubmap:hubmap /var/run/nginx.pid
+chown -R hubmap:hubmap /var/cache/nginx
+chown -R hubmap:hubmap /var/log/nginx
 
 # Lastly we use gosu to execute our process "$@" as that user
 # Remember CMD from a Dockerfile of child image gets passed to the entrypoint.sh as command line arguments

--- a/docker/ingest-api-prod/entrypoint.sh
+++ b/docker/ingest-api-prod/entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Pass the HOST_UID from an environment variable specified in the child image docker-compose,
+# defaulting to 9000 if it doesn't exist
+HOST_UID=${HOST_UID:-9000}
+
+echo "Starting ingest-api container with the same host UID: $HOST_UID"
+
+# Create a new user with the same host UID to run processes on container
+# The Filesystem doesn't really care what the user is called,
+# it only cares about the UID attached to that user
+useradd -r -u $HOST_UID -o -c "" -m hubmap
+
+# When running Nginx as a non-root user, we need to create the pid file
+# and give read and write access to /var/run/nginx.pid, /var/cache/nginx, and /var/log/nginx
+# In individual nginx *.conf, also don't listen on ports 80 or 443 because 
+# only root processes can listen to ports below 1024
+touch /var/run/nginx.pid
+chown -R hubmap /var/run/nginx.pid
+chown -R hubmap /var/cache/nginx
+chown -R hubmap /var/log/nginx
+
+# Lastly we use gosu to execute our process "$@" as that user
+# Remember CMD from a Dockerfile of child image gets passed to the entrypoint.sh as command line arguments
+# "$@" is a shell variable that means "all the arguments"
+exec /usr/local/bin/gosu hubmap "$@"

--- a/docker/ingest-api-prod/nginx.conf
+++ b/docker/ingest-api-prod/nginx.conf
@@ -1,0 +1,33 @@
+# The only change needed is to comment out the user nginx; line 
+# to avoid a warning since this directive is only meaningfull when Nginx is running as root
+# user  nginx;
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/docker/ingest-api-prod/nginx/conf.d/ingest-api.conf
+++ b/docker/ingest-api-prod/nginx/conf.d/ingest-api.conf
@@ -1,6 +1,6 @@
 # Subdomain resolve
 server {
-    listen 80;
+    listen 8080;
     server_name ingest.api.hubmapconsortium.org;
     
     location / {
@@ -9,7 +9,7 @@ server {
 }
 
 server {
-    listen 443 ssl; # managed by Certbot
+    listen 8443 ssl; # managed by Certbot
     server_name ingest.api.hubmapconsortium.org;
     root /usr/share/nginx/html;
 

--- a/docker/ingest-api-test/Dockerfile
+++ b/docker/ingest-api-test/Dockerfile
@@ -35,4 +35,10 @@ RUN yum install -y nginx && \
 # Here 5000 is for the uwsgi socket, 80 for nginx
 EXPOSE 5000 80
 
+# Set an entrypoint
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+
 CMD ["./start.sh"]

--- a/docker/ingest-api-test/Dockerfile
+++ b/docker/ingest-api-test/Dockerfile
@@ -1,8 +1,7 @@
 # Parent image
 FROM hubmap/api-base-image:latest
 
-LABEL description="HuBMAP Ingest API Service" \
-	version="1.5"
+LABEL description="HuBMAP Ingest API Service"
 
 # Change to directory that contains the Dockerfile
 WORKDIR /usr/src/app
@@ -21,11 +20,13 @@ enabled=1\n'\
 # Reduce the number of layers in image by minimizing the number of separate RUN commands
 # 1 - Install nginx (using the custom yum repo specified earlier)
 # 2 - Remove the default nginx config file
-# 3 - Install flask app dependencies with pip (pip3 also works)
-# 4 - Make the start script executable
-# 5 - Clean all yum cache
+# 3 - Overwrite the nginx.conf with ours to run nginx as non-root
+# 4 - Install flask app dependencies with pip (pip3 also works)
+# 5 - Make the start script executable
+# 6 - Clean all yum cache
 RUN yum install -y nginx && \
     rm /etc/nginx/conf.d/default.conf && \
+    mv nginx.conf /etc/nginx/nginx.conf && \
     pip install -r src/requirements.txt && \
     chmod +x start.sh && \
     yum clean all 

--- a/docker/ingest-api-test/entrypoint.sh
+++ b/docker/ingest-api-test/entrypoint.sh
@@ -1,24 +1,31 @@
 #!/bin/bash
 
-# Pass the HOST_UID from an environment variable specified in the child image docker-compose,
+# Pass the HOST_UID and HOST_UID from environment variables specified in the child image docker-compose,
 # defaulting to 9000 if it doesn't exist
+HOST_GID=${HOST_GID:-9000}
 HOST_UID=${HOST_UID:-9000}
 
-echo "Starting ingest-api container with the same host UID: $HOST_UID"
+echo "Starting ingest-api container with the same host user UID: $HOST_UID and GID: $HOST_GID"
 
 # Create a new user with the same host UID to run processes on container
 # The Filesystem doesn't really care what the user is called,
 # it only cares about the UID attached to that user
-useradd -r -u $HOST_UID -o -c "" -m hubmap
+# Check if user already exists and don't recreate across container restarts
+getent passwd $HOST_UID > /dev/null 2&>1
+# $? is a special variable that captures the exit status of last task
+if [ $? -ne 0 ]; then
+    groupadd -r -g $HOST_GID hubmap
+    useradd -r -u $HOST_UID -g $HOST_GID -m hubmap
+fi
 
 # When running Nginx as a non-root user, we need to create the pid file
 # and give read and write access to /var/run/nginx.pid, /var/cache/nginx, and /var/log/nginx
 # In individual nginx *.conf, also don't listen on ports 80 or 443 because 
 # only root processes can listen to ports below 1024
 touch /var/run/nginx.pid
-chown -R hubmap /var/run/nginx.pid
-chown -R hubmap /var/cache/nginx
-chown -R hubmap /var/log/nginx
+chown -R hubmap:hubmap /var/run/nginx.pid
+chown -R hubmap:hubmap /var/cache/nginx
+chown -R hubmap:hubmap /var/log/nginx
 
 # Lastly we use gosu to execute our process "$@" as that user
 # Remember CMD from a Dockerfile of child image gets passed to the entrypoint.sh as command line arguments

--- a/docker/ingest-api-test/entrypoint.sh
+++ b/docker/ingest-api-test/entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Pass the HOST_UID from an environment variable specified in the child image docker-compose,
+# defaulting to 9000 if it doesn't exist
+HOST_UID=${HOST_UID:-9000}
+
+echo "Starting ingest-api container with the same host UID: $HOST_UID"
+
+# Create a new user with the same host UID to run processes on container
+# The Filesystem doesn't really care what the user is called,
+# it only cares about the UID attached to that user
+useradd -r -u $HOST_UID -o -c "" -m hubmap
+
+# When running Nginx as a non-root user, we need to create the pid file
+# and give read and write access to /var/run/nginx.pid, /var/cache/nginx, and /var/log/nginx
+# In individual nginx *.conf, also don't listen on ports 80 or 443 because 
+# only root processes can listen to ports below 1024
+touch /var/run/nginx.pid
+chown -R hubmap /var/run/nginx.pid
+chown -R hubmap /var/cache/nginx
+chown -R hubmap /var/log/nginx
+
+# Lastly we use gosu to execute our process "$@" as that user
+# Remember CMD from a Dockerfile of child image gets passed to the entrypoint.sh as command line arguments
+# "$@" is a shell variable that means "all the arguments"
+exec /usr/local/bin/gosu hubmap "$@"

--- a/docker/ingest-api-test/nginx.conf
+++ b/docker/ingest-api-test/nginx.conf
@@ -1,0 +1,33 @@
+# The only change needed is to comment out the user nginx; line 
+# to avoid a warning since this directive is only meaningfull when Nginx is running as root
+# user  nginx;
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/docker/ingest-api-test/nginx/conf.d/ingest-api.conf
+++ b/docker/ingest-api-test/nginx/conf.d/ingest-api.conf
@@ -1,6 +1,6 @@
 # Subdomain resolve
 server {
-    listen 80;
+    listen 8080;
     server_name ingest-api.test.hubmapconsortium.org;
     
     location / {
@@ -9,7 +9,7 @@ server {
 }
 
 server {
-    listen 443 ssl; # managed by Certbot
+    listen 8443 ssl; # managed by Certbot
     server_name ingest-api.test.hubmapconsortium.org;
     root /usr/share/nginx/html;
 

--- a/docker/ingest-ui/Dockerfile
+++ b/docker/ingest-ui/Dockerfile
@@ -1,8 +1,7 @@
 # Parent image
-FROM centos:7
+FROM hubmap/api-base-image:latest
 
-LABEL description="HuBMAP Ingest UI" \
-	version="1.5"
+LABEL description="HuBMAP Ingest UI"
 
 # Change to directory that contains the Dockerfile
 WORKDIR /usr/src/app
@@ -19,17 +18,17 @@ enabled=1\n'\
 >> /etc/yum.repos.d/nginx.repo
 
 # Reduce the number of layers in image by minimizing the number of separate RUN commands
-# 1 - Update the package listings
-# 2 - Install nginx (using the custom yum repo specified earlier)
-# 3 - Remove the default nginx config file
+# 1 - Install nginx (using the custom yum repo specified earlier)
+# 2 - Remove the default nginx config file
+# 3 - Overwrite the nginx.conf with ours to run nginx as non-root
 # 4 - Use our nginx config file
 # 5 - Add Node.js stable release Yum Repository
 # 6 - Install Node.js (includes npm)
 # 7 - Install npm dependencies
 # 8 - Clean all yum cache
-RUN yum update -y && \
-    yum install -y nginx && \
+RUN yum install -y nginx && \
     rm /etc/nginx/conf.d/default.conf && \
+    mv nginx.conf /etc/nginx/nginx.conf && \
     mv ingest-ui.conf /etc/nginx/conf.d && \
     curl -sL https://rpm.nodesource.com/setup_12.x | bash - && \
     yum install -y nodejs && \
@@ -47,5 +46,11 @@ RUN npm install && \
 # EXPOSE does not make the ports of the container accessible to the host.
 # Here 80 for nginx to serve the react generated static site
 EXPOSE 80
+
+# Set an entrypoint
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/docker/ingest-ui/entrypoint.sh
+++ b/docker/ingest-ui/entrypoint.sh
@@ -5,7 +5,7 @@
 HOST_GID=${HOST_GID:-9000}
 HOST_UID=${HOST_UID:-9000}
 
-echo "Starting ingest-api container with the same host user UID: $HOST_UID and GID: $HOST_GID"
+echo "Starting ingest-ui container with the same host user UID: $HOST_UID and GID: $HOST_GID"
 
 # Create a new user with the same host UID to run processes on container
 # The Filesystem doesn't really care what the user is called,
@@ -17,6 +17,15 @@ if [ $? -ne 0 ]; then
     groupadd -r -g $HOST_GID hubmap
     useradd -r -u $HOST_UID -g $HOST_GID -m hubmap
 fi
+
+# When running Nginx as a non-root user, we need to create the pid file
+# and give read and write access to /var/run/nginx.pid, /var/cache/nginx, and /var/log/nginx
+# In individual nginx *.conf, also don't listen on ports 80 or 443 because 
+# only root processes can listen to ports below 1024
+touch /var/run/nginx.pid
+chown -R hubmap:hubmap /var/run/nginx.pid
+chown -R hubmap:hubmap /var/cache/nginx
+chown -R hubmap:hubmap /var/log/nginx
 
 # Lastly we use gosu to execute our process "$@" as that user
 # Remember CMD from a Dockerfile of child image gets passed to the entrypoint.sh as command line arguments

--- a/docker/ingest-ui/ingest-ui.conf
+++ b/docker/ingest-ui/ingest-ui.conf
@@ -1,7 +1,7 @@
 
 server {
-    # Nginx listens port 80 on its container
-    listen 80;
+    # Nginx listens port 8080 on its container
+    listen 8080;
     
     server_name localhost;
     root /usr/src/app/src/build;

--- a/docker/ingest-ui/nginx.conf
+++ b/docker/ingest-ui/nginx.conf
@@ -1,0 +1,33 @@
+# The only change needed is to comment out the user nginx; line 
+# to avoid a warning since this directive is only meaningfull when Nginx is running as root
+# user  nginx;
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+}


### PR DESCRIPTION
This PR:

- de-elevates root to hubmap user (mapped with the host UID and GID) for running nginx, uwsgi and docker processes
- the docker-compose takes UID and GID as new environment variables for passing host user info to docker container
- internal ports changes to allow nginx run as non-root process