### PR TITLE
Use the baseHref RUI option

### DIFF
--- a/src/ingest-ui/src/components/uuid/tissue_form_components/ruiIntegration.jsx
+++ b/src/ingest-ui/src/components/uuid/tissue_form_components/ruiIntegration.jsx
@@ -68,7 +68,7 @@ class RUIIntegration extends Component {
     var self = this;
     window.ruiConfig = {
       // Custom configuration
-      // baseHref: process.env.REACT_APP_RUI_BASE_URL,
+      baseHref: `${process.env.REACT_APP_RUI_BASE_URL}/`,
       embedded: (sex !== "" && sex !== undefined),
       tutorialMode: false,
       homeUrl: '/donors-samples',


### PR DESCRIPTION
This should remove the need for the assets folder on dev and will use the assets stored in the CDN. This will eliminate the reference organ data mismatch identified earlier.