### PR TITLE
Switch RUI from staging releases to official 1.x releases

### DIFF
--- a/src/ingest-ui/example.env
+++ b/src/ingest-ui/example.env
@@ -24,4 +24,4 @@ REACT_APP_READ_ONLY_GROUP_ID = '5777527e-ec11-11e8-ab41-0af86edb4424'
 REACT_APP_HUBMAP_DATA_ADMIN_GROUP = 'HuBMAP-data-admin'
 
 # RUI Base URL
-REACT_APP_RUI_BASE_URL = 'https://cdn.jsdelivr.net/gh/hubmapconsortium/ccf-ui@staging/rui/'
+REACT_APP_RUI_BASE_URL = 'https://cdn.jsdelivr.net/gh/hubmapconsortium/ccf-ui@1/rui/'


### PR DESCRIPTION
This PR changes the example.env to use the official 1.x release of the RUI. You'll need to update the actual .env in your infrastructure.