### PR TITLE
Adds Sequence Library For #397

### DIFF
--- a/src/src/constants.jsx
+++ b/src/src/constants.jsx
@@ -1,3 +1,5 @@
+
+// These ones show on the main Search/Filter page
 export const SESSION_TIMEOUT_IDLE_TIME = 30 * 1000 * 60; // min * minisecond * second
 export const SAMPLE_TYPES = [
   { donor: "Donor" },
@@ -40,14 +42,16 @@ export const SAMPLE_TYPES = [
     nuclei: "Nuclei",
     protein: "Protein",
     rna_total: "RNA, total",
-    ran_poly_a_enriched: "RNA, poly-A enriched"
+    ran_poly_a_enriched: "RNA, poly-A enriched",
+    sequence_library:"Sequence Library"
   },
   { other: "Other" }
 ];
 
+// These ones show on the Create new Donor/Sample page
 export const TISSUE_TYPES = {
    Donor: [{ 
-    organ: "Organ"
+    organ: "Organ",
   }],
    Sample: [{
     biopsy: "Biopsy",
@@ -71,6 +75,7 @@ export const TISSUE_TYPES = {
     serum: "Serum",
     single_cell_cryopreserved: "Single cell cryopreserved",
     tissue_lysate: "Tissue lysate",
+  },{
     clarity_hydrogel: "CLARITY hydrogel",
     cryosections_curls_from_fresh_frozen_oct:
       "Cryosections/curls from fresh frozen OCT",
@@ -78,12 +83,15 @@ export const TISSUE_TYPES = {
     ffpe_slide: "FFPE slide",
     fixed_frozen_section_slide: "Fixed Frozen section slide",
     fresh_frozen_section_slide: "Fresh Frozen section slide",
-    fresh_frozen_tissue_section: "Fresh Frozen Tissue Section",
+    fresh_frozen_tissue_section: "Fresh Frozen Tissue Section"
+  },{
     gdna: "gDNA",
     nuclei: "Nuclei",
     protein: "Protein",
     rna_total: "RNA, total",
     ran_poly_a_enriched: "RNA, poly-A enriched",
+    sequence_library:"Sequence Library"
+  },{
     other: "Other" }]
 };
 


### PR DESCRIPTION
Adds Sequence Library to the proper locations on the New Sample and Donor/Sample Search pages,
[add new Sequence Library sample type #397](https://github.com/hubmapconsortium/ingest-ui/issues/397)

Re-introduces divided setions for the New Sample dropdown (for Organs, not Donors)