### PR TITLE
More RUI 2.0 tweaks

### DIFF
--- a/src/public/index.html
+++ b/src/public/index.html
@@ -3,13 +3,7 @@
 
 <head>
   <base href="/" />
-  <!-- <base href="https://cdn.jsdelivr.net/gh/hubmapconsortium/ccf-ui@staging/rui/" /> -->
   <meta charset="utf-8" />
-
-  <!-- <link rel="shortcut icon" href="https://cdn.jsdelivr.net/gh/hubmapconsortium/ccf-3d-registration@staging/TemplateData/favicon.ico">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/hubmapconsortium/ccf-3d-registration@staging/TemplateData/style.css">
-    <script src="https://cdn.jsdelivr.net/gh/hubmapconsortium/ccf-3d-registration@staging/TemplateData/UnityProgress.js"></script>
-    <script src="https://cdn.jsdelivr.net/gh/hubmapconsortium/ccf-3d-registration@staging/Build/UnityLoader.js"></script> -->
 
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-136932895-2"></script>
   <script>
@@ -21,7 +15,8 @@
     gtag('config', 'UA-136932895-2');
   </script>
   <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500&amp;display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Sharp" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Sharp|Material+Icons+Outlined" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/hubmapconsortium/ccf-ui@2/rui/styles.css">
 
   <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -40,14 +35,6 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-  
-  <!-- <link rel="icon" type="image/x-icon" href="https://cdn.jsdelivr.net/gh/hubmapconsortium/ccf-ui@staging/rui/favicon.ico"> -->
-  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500&amp;display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Sharp" rel="stylesheet">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/hubmapconsortium/ccf-ui@staging/rui/styles.css">
-
-
-
   <title>HuBMAP ID Generator</title>
 </head>
 

--- a/src/src/constants.jsx
+++ b/src/src/constants.jsx
@@ -132,7 +132,7 @@ export const ORGAN_TYPES = {
   OT: "Other"
 };
 
-export const RUI_ORGAN_TYPES = ["LK", "RK", "HT", "SP", "LI"];
+export const RUI_ORGAN_TYPES = ["SK", "LI", "HT", "LK", "RK", "SP", "BR", "LY", "TH"];
 
 export const EXCLUDE_USER_GROUPS = ["2cf25858-ed44-11e8-991d-0e368f3075e8", "5777527e-ec11-11e8-ab41-0af86edb4424"];
 


### PR DESCRIPTION
Added some styling tweaks (needed styles pulled from the same BASE_URL as RUI 2.0. Currently hardcoded in index.html, but maybe it can be pulled from `process.env.REACT_APP_RUI_BASE_URL` somehow (not a React guy so I'm just doing what I can)? 

Also added a few more organs that RUI 2.0 supports. There are actually more, but we are waiting for the IRIs to make their way to this project (@shirey).