### PR TITLE
Reapply - add info message (top/bottom) for public published donor/sample

### DIFF
--- a/src/src/components/uuid/donor_form_components/donorForm.jsx
+++ b/src/src/components/uuid/donor_form_components/donorForm.jsx
@@ -235,11 +235,11 @@ class DonorForm extends Component {
           selected_group: value
         });
         break;
-	 //  case "open_consent":
-		// this.setState({
-		//   open_consent: e.target.checked
-		// });
-		// break;
+   //  case "open_consent":
+    // this.setState({
+    //   open_consent: e.target.checked
+    // });
+    // break;
       default:
         break;
     }
@@ -646,7 +646,14 @@ class DonorForm extends Component {
   render() {
     return (
       <React.Fragment>
-      
+       {this.props.editingEntity && 
+            this.props.editingEntity.data_access_level === 'public' && (
+
+            <React.Fragment>
+              <div className="alert alert-warning text-center" role="alert">This entity is no longer editable. It was locked when it became publicly 
+              accessible when data associated with it was published.</div>
+            </React.Fragment>
+          )}
         {!this.props.editingEntity && (
           <div className="row">
             <div className="col-sm-12 text-center">
@@ -1077,6 +1084,14 @@ class DonorForm extends Component {
                 </div>
               )}
               {this.renderButtons()}
+               {this.props.editingEntity && 
+                this.props.editingEntity.data_access_level === 'public' && (
+
+                <React.Fragment>
+                  <div className="alert alert-warning text-center" role="alert">This entity is no longer editable. It was locked when it became publicly 
+                    accessible when data associated with it was published.</div>
+                </React.Fragment>
+              )}
             </form>
             </Paper>
           </div>

--- a/src/src/components/uuid/tissue_form_components/tissueForm.jsx
+++ b/src/src/components/uuid/tissue_form_components/tissueForm.jsx
@@ -192,7 +192,7 @@ class TissueForm extends Component {
       });
 
 
-      console.debug('PROPS', this.props)
+      //console.debug('PROPS', this.props)
     
       try {
           let param_uuid = ""
@@ -213,12 +213,8 @@ class TissueForm extends Component {
                           if (resp.status === 200) {
                             //console.debug('api_allowable_edit_states...', resp.results);
                             ////////console.debug(resp.results);
-                            let read_only_state = !resp.results.has_write_priv;      //toggle this value sense results are actually opposite for UI
-  
-                            // THIS IS A TEMPORARY HACK TO ALWAYS ENABLE PUBLIC LEVEL ACCESS FOR EDITING
-                            if (entity_data['data_access_level'] === "public") {
-                              read_only_state = false
-                            }
+                            const read_only_state = !resp.results.has_write_priv;      //toggle this value sense results are actually opposite for UI
+                            //console.debug('HAS has_write_priv', read_only_state)
                             this.setState({
                               editingEntity: entity_data,
                               readOnly: read_only_state,   // used for hidding UI components
@@ -237,7 +233,7 @@ class TissueForm extends Component {
                 }
           });
       } catch {
-        console.debug('check for PROPS')
+        //console.debug('check for PROPS', this.props)
 
         if (this.props) {
         // run load props from  createnext previous call
@@ -324,7 +320,7 @@ class TissueForm extends Component {
 
 
       } else {
-        console.debug('NOT EDITING', this.props.entity)
+        //console.debug('NOT EDITING', this.props.entity)
 
           this.setState(
             {
@@ -1128,8 +1124,8 @@ handleAddImage = () => {
           entity_api_update_entity(this.state.editingEntity.uuid, JSON.stringify(data), JSON.parse(localStorage.getItem("info")).nexus_token)
                 .then((response) => {
                   if (response.status === 200) {
-                    console.debug('Update Entity...', this.state.related_group_ids.length );
-                    console.debug(response.results);
+                    //console.debug('Update Entity...', this.state.related_group_ids.length );
+                    //console.debug(response.results);
                     this.setState({ submit_error: false, 
                       submitting: false, 
                       show_snack: true,
@@ -1443,7 +1439,7 @@ handleAddImage = () => {
 
   handleLookUpClick = () => {
 //    console.debug('source_uuid', this.state.source_uuid)
-    console.debug('lookUpCancelled', this.state.lookUpCancelled)
+    //console.debug('lookUpCancelled', this.state.lookUpCancelled)
 
     if (!this.state.lookUpCancelled) {
       this.setState({
@@ -1484,7 +1480,7 @@ handleAddImage = () => {
   handleSelectClick = selection => {
     let ancestor_organ = ""
 
-    console.debug('tissueForm Selection', selection);
+    //console.debug('tissueForm Selection', selection);
 
     if (selection) {
       // check to see if we have an "top-level" ancestor 
@@ -1492,7 +1488,7 @@ handleAddImage = () => {
       entity_api_get_entity_ancestor( selection.row.uuid, JSON.parse(localStorage.getItem("info")).nexus_token)
         .then((response) => {
           if (response.status === 200) {
-              console.debug('Entity ancestors...', response.results);
+              //console.debug('Entity ancestors...', response.results);
               // //////console.debug(response.results);
               if (response.results.length > 0) {
                   ancestor_organ = response.results[0].organ;   // use "top" ancestor organ
@@ -1500,7 +1496,7 @@ handleAddImage = () => {
           } else {
               ancestor_organ = selection.row.organ;  // use the direct ancestor
           }
-          console.debug('here setting state vars', ancestor_organ)
+          //console.debug('here setting state vars', ancestor_organ)
           this.setState({
             source_uuid: selection.row.hubmap_id,
             source_entity: selection.row,
@@ -1590,6 +1586,14 @@ handleAddImage = () => {
           </div>   
         )}
         <div className="col-sm-12 pads">
+          {this.state.editingEntity && 
+            this.state.editingEntity.data_access_level === 'public' && (
+
+            <React.Fragment>
+              <div className="alert alert-warning text-center" role="alert">This entity is no longer editable. It was locked when it became publicly 
+              accessible when data associated with it was published.</div>
+            </React.Fragment>
+          )}
           <div className="col-sm-12 text-center"><h4>Sample Information</h4></div>
           <div
             className="alert alert-danger col-sm-10 offset-sm-1"
@@ -1682,7 +1686,6 @@ handleAddImage = () => {
                       select={this.handleSelectClick}
                       custom_title="Search for a Source ID for your Sample"
                       filter_type="Sample"
-                      modecheck="Source"
                     />
                     </DialogContent>
                      <DialogActions>
@@ -2591,6 +2594,14 @@ handleAddImage = () => {
               </div>
             )}
             {this.renderButtons()}
+            {this.state.editingEntity && 
+            this.state.editingEntity.data_access_level === 'public' && (
+
+            <React.Fragment>
+              <div className="alert alert-warning text-center" role="alert">This entity is no longer editable. It was locked when it became publicly 
+              accessible when data associated with it was published.</div>
+            </React.Fragment>
+          )}
           </form>
           
         </div>


### PR DESCRIPTION
Reapply the changes that @davism84 made earlier to start showing this message after the end of September when we disable the edit on public samples.

