### PR TITLE
Uploads unhide

### DIFF
--- a/src/src/App.js
+++ b/src/src/App.js
@@ -242,11 +242,11 @@ class App extends Component {
         show_search: false,
         showSearch: false
        }, () => {   
-          //  ONLY WORKS IN FUNCTIONAL COMPONENTS
-          // AND ALL OF OURS ARE CLASS COMPONENTS
-          // this.props.history.push("/"+this.state.formType+"/"+this.state.editNewEntity.uuid)
+        // console.debug("NewEntryStateUpdated")
       });
     }
+    
+    
     
     // if (prevProps.showSearch !== this.props.showSearch) {
     //   console.log("UPDATE this.props.showSearch");

--- a/src/src/App.js
+++ b/src/src/App.js
@@ -674,10 +674,10 @@ class App extends Component {
               
               
             )}
-            {/* {this.state.isAuthenticated && this.state.creatingNewEntity && (
+            {this.state.isAuthenticated && this.state.creatingNewEntity && (
               // Loads in for new things, not editing things
-              // <Forms formType={this.state.formType} onCancel={this.handleClose} onCreated={this.onCreated}/>
-            )} */}
+              <Forms formType={this.state.formType} onCancel={this.handleClose} onCreated={this.onCreated}/>
+            )}
                   
             {this.state.isAuthenticated && this.state.creatingNewUpload && (
                 <Dialog 

--- a/src/src/App.js
+++ b/src/src/App.js
@@ -674,10 +674,10 @@ class App extends Component {
               
               
             )}
-            {this.state.isAuthenticated && this.state.creatingNewEntity && (
+            {/* {this.state.isAuthenticated && this.state.creatingNewEntity && (
               // Loads in for new things, not editing things
-              <Forms formType={this.state.formType} onCancel={this.handleClose} onCreated={this.onCreated}/>
-            )}
+              // <Forms formType={this.state.formType} onCancel={this.handleClose} onCreated={this.onCreated}/>
+            )} */}
                   
             {this.state.isAuthenticated && this.state.creatingNewUpload && (
                 <Dialog 

--- a/src/src/components/ingest/dataset_edit.jsx
+++ b/src/src/components/ingest/dataset_edit.jsx
@@ -41,7 +41,6 @@ class DatasetEdit extends Component {
     //   label: "",
     //   description: "",
     // },
-    submit_success: null,
     source_uuid: undefined,
     source_uuid_list: [],
     contains_human_genetic_sequences: undefined,
@@ -673,8 +672,7 @@ class DatasetEdit extends Component {
 
   handleButtonClick = (i) => {
     this.setState({
-      new_status: i,
-      submitting: true
+      new_status: i
     }, () => {
       this.handleSubmit(i);
     })
@@ -763,30 +761,28 @@ class DatasetEdit extends Component {
                   this.props.onUpdated(res.data);
                 })
                 .catch((error) => {
-                  this.setState({ submit_error: true, submitting: false,  submit_success:false });
+                  this.setState({ submit_error: true, submitting: false });
                 });
             } else if (i === "processing") {
                ////console.log('Submit Dataset...');
                 ingest_api_dataset_submit(this.props.editingDataset.uuid, JSON.stringify(data), JSON.parse(localStorage.getItem("info")).nexus_token)
                   .then((response) => {
                     if (response.status === 200) {
-                      this.setState({ submit_error: false, submitting: false, submit_success:true });
                       ////console.log(response.results);
                       this.props.onUpdated(response.results);
                     } else {
-                      this.setState({ submit_error: true, submitting: false, submit_success:false });
+                      this.setState({ submit_error: true, submitting: false });
                     }
                 });
               } else { // just update
                     entity_api_update_entity(this.props.editingDataset.uuid, JSON.stringify(data), JSON.parse(localStorage.getItem("info")).nexus_token)
                       .then((response) => {
                           if (response.status === 200) {
-                            this.setState({ submit_error: false, submitting: false, submit_success:true });
                             ////console.log('Update Dataset...');
                              ////console.log(response.results);
                             this.props.onUpdated(response.results);
                           } else {
-                            this.setState({ submit_error: true, submitting: false, submit_success:false});
+                            this.setState({ submit_error: true, submitting: false });
                           }
                 });
               }
@@ -812,7 +808,6 @@ class DatasetEdit extends Component {
                      this.setState({
                         //globus_path: res.data.globus_directory_url_path,
                         display_doi: response.results.display_doi,
-                        submit_success:true,
                         //doi: res.data.doi,
                       });
                      axios
@@ -841,7 +836,7 @@ class DatasetEdit extends Component {
                     }
                   });
                   } else {
-                    this.setState({ submit_error: true, submitting: false, submit_success:false });
+                    this.setState({ submit_error: true, submitting: false });
                   }
               });
           }  //else
@@ -1817,12 +1812,6 @@ class DatasetEdit extends Component {
           {this.state.submit_error && (
             <div className='alert alert-danger col-sm-12' role='alert'>
               Oops! Something went wrong. Please contact administrator for help.
-            </div>
-          )}
-
-          {this.state.submit_success && (
-            <div className='alert alert-success col-sm-12' role='alert'>
-              Changes saved Successfully.
             </div>
           )}
           {this.renderButtons()}

--- a/src/src/components/ingest/dataset_edit.jsx
+++ b/src/src/components/ingest/dataset_edit.jsx
@@ -41,6 +41,7 @@ class DatasetEdit extends Component {
     //   label: "",
     //   description: "",
     // },
+    submit_success: null,
     source_uuid: undefined,
     source_uuid_list: [],
     contains_human_genetic_sequences: undefined,
@@ -672,7 +673,8 @@ class DatasetEdit extends Component {
 
   handleButtonClick = (i) => {
     this.setState({
-      new_status: i
+      new_status: i,
+      submitting: true
     }, () => {
       this.handleSubmit(i);
     })
@@ -761,28 +763,30 @@ class DatasetEdit extends Component {
                   this.props.onUpdated(res.data);
                 })
                 .catch((error) => {
-                  this.setState({ submit_error: true, submitting: false });
+                  this.setState({ submit_error: true, submitting: false,  submit_success:false });
                 });
             } else if (i === "processing") {
                ////console.log('Submit Dataset...');
                 ingest_api_dataset_submit(this.props.editingDataset.uuid, JSON.stringify(data), JSON.parse(localStorage.getItem("info")).nexus_token)
                   .then((response) => {
                     if (response.status === 200) {
+                      this.setState({ submit_error: false, submitting: false, submit_success:true });
                       ////console.log(response.results);
                       this.props.onUpdated(response.results);
                     } else {
-                      this.setState({ submit_error: true, submitting: false });
+                      this.setState({ submit_error: true, submitting: false, submit_success:false });
                     }
                 });
               } else { // just update
                     entity_api_update_entity(this.props.editingDataset.uuid, JSON.stringify(data), JSON.parse(localStorage.getItem("info")).nexus_token)
                       .then((response) => {
                           if (response.status === 200) {
+                            this.setState({ submit_error: false, submitting: false, submit_success:true });
                             ////console.log('Update Dataset...');
                              ////console.log(response.results);
                             this.props.onUpdated(response.results);
                           } else {
-                            this.setState({ submit_error: true, submitting: false });
+                            this.setState({ submit_error: true, submitting: false, submit_success:false});
                           }
                 });
               }
@@ -808,6 +812,7 @@ class DatasetEdit extends Component {
                      this.setState({
                         //globus_path: res.data.globus_directory_url_path,
                         display_doi: response.results.display_doi,
+                        submit_success:true,
                         //doi: res.data.doi,
                       });
                      axios
@@ -836,7 +841,7 @@ class DatasetEdit extends Component {
                     }
                   });
                   } else {
-                    this.setState({ submit_error: true, submitting: false });
+                    this.setState({ submit_error: true, submitting: false, submit_success:false });
                   }
               });
           }  //else
@@ -1812,6 +1817,12 @@ class DatasetEdit extends Component {
           {this.state.submit_error && (
             <div className='alert alert-danger col-sm-12' role='alert'>
               Oops! Something went wrong. Please contact administrator for help.
+            </div>
+          )}
+
+          {this.state.submit_success && (
+            <div className='alert alert-success col-sm-12' role='alert'>
+              Changes saved Successfully.
             </div>
           )}
           {this.renderButtons()}

--- a/src/src/components/search/SearchComponent.jsx
+++ b/src/src/components/search/SearchComponent.jsx
@@ -274,6 +274,19 @@ class SearchComponent extends Component {
         show_search: this.props.showSearch
         });
     }
+
+    console.debug("San Check",prevState.editEntity !== this.state.editEntity, this.state.editEntity)
+    if (prevState.editEntity !== this.state.editEntity && (!this.state.editEntity || this.state.editEntity === null)) {
+      console.debug("Saved, Time to Reload Search", this.state.editNewEntity)
+      this.setState({
+        editForm: false,
+        show_modal: false,
+        show_search: true,
+        showSearch: true
+        }, () => {   
+          console.debug("Saved State set state settled")
+      });
+    }
     
   }
 
@@ -607,6 +620,8 @@ class SearchComponent extends Component {
       loading: false
     }, () => {   
       console.debug("onUpdated state", this.state)
+      // this.handleSearchClick();
+      this.cancelEdit();
       // ONLY works for functional components and all oura are class components
        // this.props.history.push("/"+this.state.formType+"/"+this.state.editNewEntity.uuid)
        this.setState({ redirect: true })
@@ -748,7 +763,9 @@ class SearchComponent extends Component {
                     this.state.datarows.length > 0 && (
               this.renderTable())
           }
-          {this.renderEditForm()}
+          {!this.state.show_search && (
+            this.renderEditForm()
+          )}
 
         </div>
       );

--- a/src/src/components/search/SearchComponent.jsx
+++ b/src/src/components/search/SearchComponent.jsx
@@ -103,10 +103,10 @@ class SearchComponent extends Component {
         }
        
       }else if( !this.props.modecheck && 
-              (window.location.href.includes("/donor") || 
-              window.location.href.includes("/sample") || 
-              window.location.href.includes("/dataset") || 
-              window.location.href.includes("/upload"))){
+              (window.location.href.includes("/donors") || 
+              window.location.href.includes("/samples") || 
+              window.location.href.includes("/datasets") || 
+              window.location.href.includes("/uploads"))){
         this.setState({
           sampleType: lastSegment,
           sample_type: lastSegment,

--- a/src/src/components/search/SearchComponent.jsx
+++ b/src/src/components/search/SearchComponent.jsx
@@ -103,10 +103,10 @@ class SearchComponent extends Component {
         }
        
       }else if( !this.props.modecheck && 
-              (window.location.href.includes("/donors") || 
-              window.location.href.includes("/samples") || 
-              window.location.href.includes("/datasets") || 
-              window.location.href.includes("/uploads"))){
+              (window.location.href.includes("/donor") || 
+              window.location.href.includes("/sample") || 
+              window.location.href.includes("/dataset") || 
+              window.location.href.includes("/upload"))){
         this.setState({
           sampleType: lastSegment,
           sample_type: lastSegment,

--- a/src/src/components/search/SearchComponent.jsx
+++ b/src/src/components/search/SearchComponent.jsx
@@ -435,7 +435,7 @@ class SearchComponent extends Component {
       // console.debug("sample_type", sample_type);
       // console.debug(this.props);
       if(!this.state.uuid && sample_type !=="----"){ 
-        this.handleUrlChange(this.handleSingularty(sample_type, "plural"));
+        //this.handleUrlChange(this.handleSingularty(sample_type, "plural"));
       }
       
 
@@ -602,8 +602,8 @@ class SearchComponent extends Component {
     console.debug("onUpdated SC", data)
     this.setState({
       updateSuccess: true,
-      editingEntity: data,
-      show_search: false,
+      editingEntity: null,
+      show_search: true,
       loading: false
     }, () => {   
       console.debug("onUpdated state", this.state)

--- a/src/src/components/uploads/editUploads.jsx
+++ b/src/src/components/uploads/editUploads.jsx
@@ -282,6 +282,8 @@ class EditUploads extends Component {
 
   //@TODO: DRY this out 
   handleValidateUploadSubmission = (i) => {
+    this.setState({ submitting_submission: true });
+    console.debug("handleValidateUploadSubmission")
     this.validateForm().then((isValid) => {
       if (isValid) {
         if (
@@ -295,7 +297,7 @@ class EditUploads extends Component {
             GroupSelectShow: false,
             submitting_submission: true,
           });
-          this.setState({ submitting_submission: true });
+         
 
 
           // package the data up
@@ -310,7 +312,7 @@ class EditUploads extends Component {
             console.debug(JSON.stringify(data));
             console.debug(JSON.parse(localStorage.getItem("info")));
             // if user selected Publish
-            ingest_api_validate_upload(this.props.editingUpload.uuid, JSON.stringify(data), JSON.parse(localStorage.getItem("info")).nexus_token)
+            ingest_api_submit_upload(this.props.editingUpload.uuid, JSON.stringify(data), JSON.parse(localStorage.getItem("info")).nexus_token)
               .then((response) => {
                 console.debug("ingest_api_validate_upload",response.results);
                 if (response.status === 200) {
@@ -498,8 +500,10 @@ class EditUploads extends Component {
       console.debug("handleButtonClick ",i, action)
       if(action){
         if(action === "save" || action === "create"){
+          console.debug("SAVE")
           this.handleValidateUpload(i);
         }else if(action==="submit"){
+          console.debug("SUB")
         this.handleValidateUploadSubmission(i);
         }
       }

--- a/src/src/components/uploads/editUploads.jsx
+++ b/src/src/components/uploads/editUploads.jsx
@@ -266,13 +266,12 @@ class EditUploads extends Component {
             // if user selected Publish
             ingest_api_validate_upload(this.props.editingUpload.uuid, JSON.stringify(data), JSON.parse(localStorage.getItem("info")).nexus_token)
               .then((response) => {
-                console.debug("ingest_api_validate_upload",response.results);
-                if (response.status === 200) {
-                  this.props.onUpdated(this.props.editingUpload);
-                  this.setState({ submit_error: false, submit_success:true, submitting: false });
-                } else {
-                  this.setState({ submit_error: true, submitting: false });
-                }
+                console.debug(response.results);
+                  if (response.status === 200) {
+                    this.props.onUpdated(response.results);
+                  } else {
+                    this.setState({ submit_error: true, submitting: false });
+                  }
             });
           } 
         }
@@ -314,14 +313,12 @@ class EditUploads extends Component {
             // if user selected Publish
             ingest_api_submit_upload(this.props.editingUpload.uuid, JSON.stringify(data), JSON.parse(localStorage.getItem("info")).nexus_token)
               .then((response) => {
-                console.debug("ingest_api_validate_upload",response.results);
-                if (response.status === 200) {
-                  this.props.onUpdated(this.props.editingUpload);
-                  //@TODO: Maybe control this in different stat functions we can call, that'll turn off the buttons and generate the right respinse alert perhaps in a switch ?
-                  this.setState({ submit_error: false, submit_success:true, submitting_submission:false,  submitting: false });
-                } else {
-                  this.setState({ submit_error: true, submit_success:false, submitting_submission:false, submitting: false });
-                }
+                console.debug(response.results);
+                  if (response.status === 200) {
+                    this.props.onUpdated(response.results);
+                  } else {
+                    this.setState({ submit_error: true, submitting: false, submitting_submission:false  });
+                  }
             });
           } 
         }
@@ -863,11 +860,13 @@ class EditUploads extends Component {
             </div>
           )}
 
-          {this.state.submit_success && (
+
+            {/*  this shouldnt happen! Success redirects to home */}
+          {/* {this.state.submit_success && (
             <div className='alert alert-success col-sm-12' role='alert'>
               Changes saved Successfully.
             </div>
-          )}
+          )} */}
 
 
           </div>

--- a/src/src/components/uuid/tissue_form_components/tissueForm.jsx
+++ b/src/src/components/uuid/tissue_form_components/tissueForm.jsx
@@ -467,6 +467,8 @@ class TissueForm extends Component {
                        
                       }         
               });
+            }else{
+              console.debug("ERR response, ", response)
             }
       });
     }
@@ -1146,6 +1148,8 @@ handleAddImage = () => {
                   } else {
                     this.setState({ submit_error: true, submitting: false, isDirty: false });
                     this.setDirty(false);
+          entity_api_update_entity(this.state.editingEntity.uuid, JSON.stringify(data), JSON.parse(localStorage.getItem("info")).nexus_token)
+                    console.debug("update Entity Fail", response)
 
                   }
       
@@ -1190,6 +1194,8 @@ handleAddImage = () => {
                 }
           }
         }
+      }else{
+        console.debug("NotValid!", this.state.formErrors)
       }
     });
   };
@@ -1500,7 +1506,8 @@ handleAddImage = () => {
           } else {
               ancestor_organ = selection.row.organ;  // use the direct ancestor
           }
-          //console.debug('here setting state vars', ancestor_organ)
+          console.debug('here setting state vars', ancestor_organ)
+          console.debug(selection.row)
           this.setState({
             source_uuid: selection.row.hubmap_id,
             source_entity: selection.row,

--- a/src/src/service/entity_api.js
+++ b/src/src/service/entity_api.js
@@ -53,7 +53,13 @@ export function entity_api_update_entity(uuid, data, auth) {
         return {status: res.status, results: results}
       })
       .catch(err => {
-        return {status: err.response.status, results: err.response.data}
+        var response = "";
+        if(err.response){
+          response =  {status: err.response.status, results: err.response.data}
+        }else{
+          response = err
+        }
+        return response
       });
 };
 

--- a/src/src/service/entity_api.js
+++ b/src/src/service/entity_api.js
@@ -173,7 +173,7 @@ export function entity_api_get_entity_ancestor(uuid, auth) {
   return axios 
     .get(url,options)
       .then(res => {
-        //console.debug(res);
+        console.debug(res);
           let results = res.data;
       
         return {status: res.status, results: results}


### PR DESCRIPTION
Attempting to have the Search table re-load after saving an entity, so it'll contain the newly updated data
Removes the lingering Upload Edit form from under the Search Component post-save