### PR TITLE
Upload/Register Label fix

### DIFF
--- a/src/src/App.js
+++ b/src/src/App.js
@@ -294,6 +294,7 @@ class App extends Component {
   };
 
   handleUrlChange = (targetPath) =>{  
+    
     console.debug("handleUrlChange "+targetPath)
     console.debug(this.state.creatingNewEntity)
       window.history.pushState(
@@ -354,15 +355,21 @@ class App extends Component {
   }
 
   handleMenuDropdown = (event) => {
-    this.setState(prevState => ({
-      showDropDown: !prevState.showDropDown
-    }))
+    console.debug("this.state.showDropDown",this.state.showDropDown);
+    this.setState({
+      anchorElB: null,
+      anchorElS: null,
+      showDropDown:false
+      })
   };
   
 
   handleUploadsDialog = (event) => {
+    console.debug("handleUploadsDialog");
+    this.handleMenuDropdown();
     this.setState({
       creatingNewUpload: true,
+      showDropDown: false
     });
     this.handleUrlChange("new/upload");
   }
@@ -550,7 +557,7 @@ class App extends Component {
                   >
                     <MenuItem onClick={this.handleBulkSelection}>Donors</MenuItem>
                     <MenuItem onClick={this.handleBulkSelection}>Samples</MenuItem>
-                    <MenuItem onClick={this.handleBulkSelection}>Data</MenuItem>
+                    <MenuItem onClick={this.handleUploadsDialog}>Data</MenuItem>
                   </Menu>
 
                 </div>

--- a/src/src/components/ingest/bulk.jsx
+++ b/src/src/components/ingest/bulk.jsx
@@ -430,9 +430,9 @@ showUploadedStuff(){
   })
 }
 
-renderStatusButon = () =>{
+renderStatusButon = (message) =>{
   if(!this.state.loading){
-    return("Upload");
+    return(message);
   }else{
     return(
       <FontAwesomeIcon
@@ -497,7 +497,7 @@ renderFileGrabber = () =>{
               style={{ padding: "12px" }} 
               variant="contained" 
               color="primary" >
-                {this.renderStatusButon()}
+                {this.renderStatusButon("Upload")}
             </Button>
           )}
           {this.state.tsvFile.size > 0 && !this.state.error_status && !this.state.loading &&(
@@ -571,7 +571,7 @@ renderFileGrabber = () =>{
                   style={{ padding: "12px" }} 
                   variant="contained" 
                   color="primary" >
-                  {this.renderStatusButon()}
+                  {this.renderStatusButon("Register")}
                 </Button>
               </span>
             )}


### PR DESCRIPTION
The registration button is labeled "Upload", which looks confusing with the "file successfully uploaded" Response from the prior Uploading step. Now correctly reads "Register" to reflect the correct action.  