### PR TITLE
Handle incorrectly populated user prop

### DIFF
--- a/src/src/components/uuid/tissue_form_components/ruiIntegration.jsx
+++ b/src/src/components/uuid/tissue_form_components/ruiIntegration.jsx
@@ -72,7 +72,7 @@ class RUIIntegration extends Component {
     const organ_name = organ_info[0].toLowerCase().trim();
     const organ_side = organ_info[1]?.replace(/\(|\)/g, "").toLowerCase();
     const sex = this.props.sex;
-    const user_name = this.props.user;
+    const user_name = this.props.user || "";
     const location = this.props.location === "" ? null : JSON.parse(this.props.location);
     const self = this;
 


### PR DESCRIPTION
Somehow user is being passed as null to the rui integration code. I put in a guard to protect against it and not fail, but ultimately, user _should_ be being passed in here.