### PR TITLE
Small PR for Search Result Order

### DIFF
--- a/src/src/service/search_api.js
+++ b/src/src/service/search_api.js
@@ -180,7 +180,7 @@ console.debug("Fields", fields);
     .query(boolQuery)
     .from(from)
     .size(size)
-    .sort(esb.sort('last_modified_timestamp', 'desc'))
+    .sort(esb.sort('last_modified_timestamp', 'asc'))
     .source(colFields);
   //requestBody.query(boolQuery).size(100);
 


### PR DESCRIPTION
Sorts Search Results ASC instead of DESC, so the Oldest appears First instead of Last. Fixes #813 