### PR TITLE
Source Organ information Render

### DIFF
--- a/src/src/components/uuid/tissue_form_components/tissueForm.jsx
+++ b/src/src/components/uuid/tissue_form_components/tissueForm.jsx
@@ -365,7 +365,9 @@ class TissueForm extends Component {
             source_entity_type: this.state.editingEntity.direct_ancestor.entity_type,
           } );
 
-        this.getSourceAncestorOrgan(this.state.editingEntity);
+          if(this.state.editingEntity.direct_ancestor.entity_type === "Donor" || this.state.editingEntity.direct_ancestor.entity_type === "Organ"){
+            this.getSourceAncestorOrgan(this.state.editingEntity);
+          }
 
 
       } else {


### PR DESCRIPTION
Only renders Source Organ if sample is a block specifically from an organ, 
otherwise renders Direct ancestor Information
(addresses #811 )