### PR TITLE
Fix Missing Next Version Link

### DIFF
--- a/src/src/components/ingest/dataset_edit.jsx
+++ b/src/src/components/ingest/dataset_edit.jsx
@@ -333,7 +333,8 @@ class DatasetEdit extends Component {
           console.debug("next_revision_uuid",this.props.editingDataset.next_revision_uuid);
           entity_api_get_entity(this.props.editingDataset.next_revision_uuid, JSON.parse(localStorage.getItem("info")).groups_token)
           .then((response) => {
-            if(response.hubmap_id){
+            console.debug("next_revision_uuid RESPONSE",response.results);
+            if(response.results.hubmap_id){
               this.setState({nextHID: response.results.hubmap_id})
             }else{
               console.debug("next_revision_uuid",response);


### PR DESCRIPTION
Fix Issue with returning Next Revision information for Datasets where the UUID is now wrapped inside response.results & no longer simply response (#1140 )