### PR TITLE
Removes Upload Validation for Currators & Group Editors

### DIFF
--- a/src/src/components/uploads/editUploads.jsx
+++ b/src/src/components/uploads/editUploads.jsx
@@ -578,7 +578,8 @@ class EditUploads extends Component{
    
     if (["SUBMITTED", "VALID", "INVALID", "ERROR", "NEW"].includes(
       this.state.status.toUpperCase() 
-      ) && (this.state.data_admin || this.state.data_curator || this.state.data_group_editor)) {
+      // ) && (this.state.data_admin || this.state.data_curator || this.state.data_group_editor)) {
+      ) && (this.state.data_admin)) {
       return (
               <Button
               variant="contained" 


### PR DESCRIPTION
Remove the Validate button for user roles data_curator & data_group_editor ([#1193](https://github.com/hubmapconsortium/ingest-ui/issues/1193))