### PR TITLE
Env var name fix

### DIFF
--- a/src/example.env
+++ b/src/example.env
@@ -29,5 +29,5 @@ REACT_APP_RUI_BASE_URL = 'https://cdn.jsdelivr.net/gh/hubmapconsortium/ccf-ui@3/
 REACT_APP_INGEST_BOARD_URL = 'https://ingest-board.dev.hubmapconsortium.org/'
 
 # The Usergroup IDS associated with Currators and Admin
-DATA_ADMIN = '89a69625-99d7-11ea-9366-0e98982705c1'
-DATA_CURATOR = '75804b96-d4a8-11e9-9da9-0ad4acb67ed4'
+REACT_APP_DATA_ADMIN = '89a69625-99d7-11ea-9366-0e98982705c1'
+REACT_APP_DATA_CURATOR = '75804b96-d4a8-11e9-9da9-0ad4acb67ed4'


### PR DESCRIPTION
Updates DATA_ADMIN and DATA_CURATOR to REACT_APP_DATA_ADMIN and REACT_APP_DATA_CURATOR so they're not dropped by react-scripts