### PR TITLE
Selectively render helper text on data Uploads based on availablility

### DIFF
--- a/src/src/components/search/searchTable.jsx
+++ b/src/src/components/search/searchTable.jsx
@@ -265,6 +265,7 @@ export const RenderSearchTable = (props) => {
   }
         
   function handleSearchClick(event) {
+    
     if(event){event.preventDefault()}
     setTableLoading(true);
     setPage(0)

--- a/src/src/components/uploads/editUploads.jsx
+++ b/src/src/components/uploads/editUploads.jsx
@@ -654,8 +654,7 @@ class EditUploads extends Component{
 
  renderSaveButton() {
     if (["VALID","INVALID", "ERROR", "NEW"].includes(this.state.status.toUpperCase()) && 
-      (this.state.data_admin || this.state.data_curator || this.state.data_group_editor) &&
-      this.state.writeable) {
+      (this.state.data_admin || this.state.data_curator || this.state.data_group_editor)){
       return (
             <Button
             variant="contained"
@@ -715,7 +714,7 @@ renderReorganizeButton() {
   renderHelperText = () => {
       return(
         <div className="helper-text p-2 m-2 align-right w-100 text-right">
-          {["VALID","INVALID", "ERROR", "NEW"].includes(this.state.status.toUpperCase()) && (this.state.data_admin || this.state.data_curator || this.state.data_group_editor) && this.state.writeable && (
+          {["VALID","INVALID", "ERROR", "NEW"].includes(this.state.status.toUpperCase()) && (this.state.data_admin || this.state.data_curator || this.state.data_group_editor) && (
             <p className="text-small text-end p-0 m-0">Use the <strong>Save</strong> button to save any updates to the Title or Description.</p>
           )}
           {["VALID"].includes(this.state.status.toUpperCase()) && (this.state.data_admin || this.state.data_group_editor) && (

--- a/src/src/components/uploads/editUploads.jsx
+++ b/src/src/components/uploads/editUploads.jsx
@@ -653,9 +653,9 @@ class EditUploads extends Component{
   }
 
  renderSaveButton() {
-    if (["VALID","INVALID", "ERROR", "NEW"].includes(
-      this.state.status.toUpperCase()
-      ) && (this.state.data_admin || this.state.data_curator || this.state.data_group_editor)) {
+    if (["VALID","INVALID", "ERROR", "NEW"].includes(this.state.status.toUpperCase()) && 
+      (this.state.data_admin || this.state.data_curator || this.state.data_group_editor) &&
+      this.state.writeable) {
       return (
             <Button
             variant="contained"
@@ -713,15 +713,17 @@ renderReorganizeButton() {
 
 
   renderHelperText = () => {
-    if(this.state.writeable){
       return(
         <div className="helper-text p-2 m-2 align-right w-100 text-right">
-          <p className="text-small text-end p-0 m-0">Use the <strong>Submit</strong> button when all data has been uploaded and is ready for HIVE review.</p>
-          <p className="text-small text-end p-0 
-          m-0">Use the <strong>Save</strong> button to save any updates to the Title or Description.</p>
+          {["VALID","INVALID", "ERROR", "NEW"].includes(this.state.status.toUpperCase()) && (this.state.data_admin || this.state.data_curator || this.state.data_group_editor) && this.state.writeable && (
+            <p className="text-small text-end p-0 m-0">Use the <strong>Save</strong> button to save any updates to the Title or Description.</p>
+          )}
+          {["VALID"].includes(this.state.status.toUpperCase()) && (this.state.data_admin || this.state.data_group_editor) && (
+            <p className="text-small text-end p-0 m-0">Use the <strong>Submit</strong> button when all data has been uploaded and is ready for HIVE review.</p>
+          )}
         </div>
       )
-    }
+    
   }
   
   componentDidUpdate(prevProps) { 
@@ -932,11 +934,7 @@ renderReorganizeButton() {
       </div>
       );
     }
-
-    
-
   }
-
 
   renderValidationMessage (){
     if(this.state.validation_message){
@@ -950,12 +948,9 @@ renderReorganizeButton() {
       }
     }
   }
-
-
   
-    // dev int
   render() {
-    console.debug('%c⊙ ALLGROUPS', 'color:#00ff7b', this.props.allGroups );
+    // console.debug('%c⊙ ALLGROUPS', 'color:#00ff7b', this.props.allGroups );
     return (
       <React.Fragment>
         <form>


### PR DESCRIPTION
Selectively render helper text on data Uploads based on availability of actions, fix Save button rendering when upload isn't actually writable