### PR TITLE
Add incomplete status to list to render save button - #1424

### DIFF
--- a/src/src/components/uploads/editUploads.jsx
+++ b/src/src/components/uploads/editUploads.jsx
@@ -671,7 +671,7 @@ class EditUploads extends Component{
   }
 
  renderSaveButton() {
-    if (["VALID","INVALID", "ERROR", "NEW"].includes(this.state.status.toUpperCase()) && 
+    if (["VALID","INVALID", "ERROR", "NEW", "INCOMPLETE"].includes(this.state.status.toUpperCase()) &&
       (this.state.data_admin || this.state.data_curator || this.state.data_group_editor)){
       return (
             <Button


### PR DESCRIPTION
Change log:
1. Allow Save button to be visible on Incomplete status
<img width="378" alt="Screen Shot 2024-08-08 at 3 25 47 PM" src="https://github.com/user-attachments/assets/4ea5cfca-ab62-4d75-919c-09a21b3d8344">

Needs admin testing. 