### PR TITLE
Enable Creation of Collections/EPICollections for Admin users

### DIFF
--- a/src/src/App.css
+++ b/src/src/App.css
@@ -910,3 +910,15 @@ svg.invalid {
   border-radius: 5px;
   font-size: inherit!important;
 }
+
+.title_badge{
+  align-items: center;
+  color: rgb(42, 111, 184);
+  display: inline-flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  font-size: 0.95rem;
+  font-weight: 300;
+  gap: 4px;
+  line-height: 1.5;
+}

--- a/src/src/assets/App.css
+++ b/src/src/assets/App.css
@@ -845,3 +845,14 @@ svg.invalid{
   border-radius: 5px;
   font-size: inherit!important;
 }
+.title_badge{
+  align-items: center;
+  color: rgb(42, 111, 184);
+  display: inline-flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  font-size: 0.95rem;
+  font-weight: 300;
+  gap: 4px;
+  line-height: 1.5;
+}

--- a/src/src/components/collections/collections.jsx
+++ b/src/src/components/collections/collections.jsx
@@ -29,7 +29,7 @@ import Alert from '@mui/material/Alert';
 import Collapse from '@mui/material/Collapse';
 import LinearProgress from '@material-ui/core/LinearProgress';
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faQuestionCircle, faSpinner, faTrash, faCheck,faExclamationTriangle, faPlus,faPenToSquare } from "@fortawesome/free-solid-svg-icons";
+import { faQuestionCircle, faUpRightFromSquare, faSpinner, faTrash, faCheck,faExclamationTriangle, faPlus,faPenToSquare } from "@fortawesome/free-solid-svg-icons";
 import Typography from '@mui/material/Typography';
 import IconButton from '@mui/material/IconButton';
 import CancelPresentationIcon from '@mui/icons-material/CancelPresentation';
@@ -631,7 +631,6 @@ export function CollectionForm (props){
         </>
       )
     }
-    
     var renderAssociationTable = () => {
       var hiddenFields = [];
       var uniqueTypes = new Set(associatedEntities.map(obj => obj.entity_type.toLowerCase()));
@@ -723,6 +722,11 @@ export function CollectionForm (props){
               </h3>
               {!props.newForm && (
                 <h5>{props.editingCollection.title}</h5>
+              )}
+              {editingCollection && editingCollection.doi_url  && (
+                <h4 className="title_badge">
+                  doi: <a href={editingCollection.doi_url} target='_blank' >{editingCollection.doi_url} </a><FontAwesomeIcon icon={faUpRightFromSquare}/>
+                </h4>
               )}
             </div>
           </div>
@@ -919,18 +923,7 @@ export function CollectionForm (props){
             value={formValues.title}
           />
         </FormControl>
-        {editingCollection && editingCollection.doi_url   && (
-          <FormControl>
-            <TextField
-              label="DOI url"
-              name="DOIurl"
-              id="DOIurl"
-              disabled={true}
-              variant="standard"
-              value={editingCollection.doi_url}
-            />
-          </FormControl>
-        )}
+
         <FormControl>
           <TextField
             label="Description"

--- a/src/src/components/collections/collections.jsx
+++ b/src/src/components/collections/collections.jsx
@@ -979,7 +979,7 @@ export function CollectionForm (props){
 
         <div className="row">
           <div className="buttonWrapRight">
-            {userAdmin === true && !editingCollection.doi_url && (          
+            {userAdmin === true && (editingCollection && !editingCollection.doi_url) && (          
               <LoadingButton 
                 loading={publishing}
                 onClick={() => handlePublish()}

--- a/src/src/components/collections/epicollections.jsx
+++ b/src/src/components/collections/epicollections.jsx
@@ -31,7 +31,7 @@ import Alert from '@mui/material/Alert';
 import Collapse from '@mui/material/Collapse';
 import LinearProgress from '@material-ui/core/LinearProgress';
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faQuestionCircle, faSpinner, faTrash, faExclamationTriangle, faCheck, faPlus,faPenToSquare } from "@fortawesome/free-solid-svg-icons";
+import { faQuestionCircle, faSpinner, faUpRightFromSquare, faTrash, faExclamationTriangle, faCheck, faPlus,faPenToSquare } from "@fortawesome/free-solid-svg-icons";
 import Typography from '@mui/material/Typography';
 import IconButton from '@mui/material/IconButton';
 import CancelPresentationIcon from '@mui/icons-material/CancelPresentation';
@@ -743,6 +743,11 @@ export function EPICollectionForm (props){
             {!props.newForm && (
               <h5>{props.editingCollection.title}</h5>
             )}
+            {editingCollection && editingCollection.doi_url  && (
+              <h4 className="title_badge">
+                doi: <a href={editingCollection.doi_url} target='_blank' >{editingCollection.doi_url} </a><FontAwesomeIcon icon={faUpRightFromSquare}/>
+              </h4>
+            )}
           </div>
         </div>
 
@@ -938,18 +943,6 @@ export function EPICollectionForm (props){
           value={formValues.title}
         />
       </FormControl>
-      {editingCollection && editingCollection.doi_url  && (
-          <FormControl>
-            <TextField
-              label="DOI url"
-              name="DOIurl"
-              id="DOIurl"
-              disabled={true}
-              variant="standard"
-              value={editingCollection.doi_url}
-            />
-          </FormControl>
-        )}
       <FormControl>
         <TextField
           label="Description"

--- a/src/src/components/collections/epicollections.jsx
+++ b/src/src/components/collections/epicollections.jsx
@@ -1000,7 +1000,7 @@ export function EPICollectionForm (props){
 
       <div className="row">
         <div className="buttonWrapRight">
-          {userAdmin === true && !editingCollection.doi_url && (          
+          {userAdmin === true && (editingCollection && !editingCollection.doi_url) && (          
             <LoadingButton 
               loading={publishing}
               onClick={() => handlePublish()}


### PR DESCRIPTION
Admin need access to the Creation forms for Collections and EPICollections per slack/@yuanzhou 
this does not account for any top menu link access for Admins who dont already have the menu through their Data Provider access, or any changes needed to allow edit access for previously denied creation of other entities, [(outlined here)](https://github.com/hubmapconsortium/ingest-ui/issues/872), nor updating that table, nor the creation/documentation of new Admin/Provider Combined Account. 

Now includes repositioned doi link 
