### PR TITLE
Replace legacy Button w updated Button

### DIFF
--- a/src/src/components/uuid/tissue_form_components/tissueForm.jsx
+++ b/src/src/components/uuid/tissue_form_components/tissueForm.jsx
@@ -10,8 +10,8 @@ import Snackbar from '@mui/material/Snackbar';
 
 // import Snackbar from '@material-ui/core/Snackbar';
 //import SnackbarContent from '@material-ui/core/SnackbarContent';
-import Button from '@material-ui/core/Button';
-// import Button from '@mui/material/Button';
+// import Button from '@material-ui/core/Button';
+import Button from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
 import LinearProgress from '@mui/material/LinearProgress';
 // import IconButton from '@material-ui/core/IconButton';


### PR DESCRIPTION
Replace legacy material-ui Button component with updated MUI button component (Looks like Deprecated button component was overriding the modern one loaded in from the nav #1431)