### PR TITLE
Read Only User UUID Crash Fix

### DIFF
--- a/src/src/components/newDonor.jsx
+++ b/src/src/components/newDonor.jsx
@@ -48,8 +48,6 @@ export const DonorForm = (props) => {
     protocol_url: "",
     description: "",
   });
-  const userGroups = JSON.parse(localStorage.getItem("userGroups"));
-  const defaultGroup = userGroups[0].uuid;
   var[formValues, setFormValues] = useState({
     lab_donor_id: "",
     label: "",
@@ -324,7 +322,7 @@ export const DonorForm = (props) => {
                   BorderTopRightRadius: "4px",
                 }}
                 disabled={uuid?true:false}
-                value={formValues.group_uuid ? formValues.group_uuid : defaultGroup}>
+                value={formValues.group_uuid ? formValues.group_uuid : ""}>
                 <UserGroupSelectMenu formValues={formValues} />
               </NativeSelect>
             </Box>

--- a/src/src/components/newSample.jsx
+++ b/src/src/components/newSample.jsx
@@ -57,9 +57,7 @@ export const SampleForm = (props) => {
   let [ruiEnabled, setRuiEnabled] = React.useState(false);
   let [RUIJson, setRUIJson] = React.useState(false);
   let [RUIDetails, setRUIDetails] = React.useState([null,null]);
-  const userGroups = JSON.parse(localStorage.getItem("userGroups"));
   const userInfo = JSON.parse(localStorage.getItem("info"));
-  const defaultGroup = userGroups[0].uuid;
   let organ_types = JSON.parse(localStorage.getItem("organs"));
   let[permissions,setPermissions] = useState( { 
     has_admin_priv: false,
@@ -373,8 +371,10 @@ export const SampleForm = (props) => {
         // We're in Create mode
 
         // They might not have changed the Group Selector, so lets check for the value
+        // actually there will always be /A/ value, so no need to mess with grabbing a default group
         let selectedGroup = document.getElementById("group_uuid");
-        sampleFormData.group_uuid = selectedGroup?.value ? selectedGroup.value : defaultGroup;
+        sampleFormData.group_uuid = selectedGroup?.value ? selectedGroup.value : "";
+        // sampleFormData.group_uuid = selectedGroup?.value ? selectedGroup.value : defaultGroup;
         
         // We need to add the Category back to the Form being submitted 
         sampleFormData.sample_category = ((formValues.sample_category === "" && formValues.organ) ? "organ": formValues.sample_category)
@@ -875,7 +875,7 @@ export const SampleForm = (props) => {
                   BorderTopRightRadius: "4px",
                 }}
                 disabled={uuid?true:false}
-                value={formValues.group_uuid ? formValues.group_uuid : defaultGroup}>
+                value={formValues.group_uuid ? formValues.group_uuid : ""}>
                 <UserGroupSelectMenu formValues={formValues} />
               </NativeSelect>
             </Box>

--- a/src/src/components/newUpload.jsx
+++ b/src/src/components/newUpload.jsx
@@ -89,9 +89,7 @@ export const UploadForm = (props) => {
   let[globusPath, setGlobusPath] = useState(null);
   let[datasetMenu, setDatasetMenu] = useState();
   let[expandVMessage, setExpandVMessage] = useState(false);
-  const userGroups = JSON.parse(localStorage.getItem("userGroups"));
   const allGroups = JSON.parse(localStorage.getItem("allGroups"));
-  const defaultGroupUUID = userGroups[0].uuid;
   let saveStatuses = ["submitted", "valid", "invalid", "error", "new"]
   let validateStatuses = ["valid", "invalid", "error", "new", "incomplete"]
   let[validationError, setValidationError] = useState(null);
@@ -318,7 +316,7 @@ export const UploadForm = (props) => {
     setProcessingButton(target)
     if(validateForm()){
       let selectedGroup = document.getElementById("group_uuid");
-      let selectedGroupUUID = (!uuid && selectedGroup?.value) ? selectedGroup.value : defaultGroupUUID;
+      let selectedGroupUUID = (!uuid && selectedGroup?.value) ? selectedGroup.value : "";
       let cleanForm ={
         title: formValues.title,
         description: formValues.description,
@@ -859,7 +857,7 @@ export const UploadForm = (props) => {
                     onChange={(e) => handleInputChange(e)}
                     fullWidth
                     disabled={uuid?true:false}
-                    value={formValues.group_uuid ? formValues.group_uuid : defaultGroupUUID}>
+                    value={formValues.group_uuid ? formValues.group_uuid : ""}>
                     <option key={"0"} value={null}></option>
                     <UserGroupSelectMenu formValues={formValues} />
                   </NativeSelect>

--- a/src/src/components/ui/formParts.jsx
+++ b/src/src/components/ui/formParts.jsx
@@ -32,9 +32,10 @@ import HIPPA from "./HIPPA";
 
 export const FormHeader = (props) => {
   let entityData = props.entityData;
+  let details = (props.entityData[0]!=="new") ? `${entityData.entity_type}: ${entityData.hubmap_id}` : `New ${props.entityData[1]}`;
   let permissions = props.permissions;
   let globusURL = props.globusURL;
-  document.title = `HuBMAP Ingest Portal | ${entityData.entity_type}: ${entityData.hubmap_id}`; //@TODO - somehow handle this detection in App
+  document.title = `HuBMAP Ingest Portal | ${details}`; //@TODO - somehow handle this detection in App
   return (
     <React.Fragment>
       {topHeader(entityData)}


### PR DESCRIPTION
Fix issue with readgroup-specific user accounts without DataProvider experiencing a crash on loading entity forms.
(addresses #1688)

Also Fixes Undefined window titles on new forms
