### PR TITLE
Concurrent Sample Reg Flow

### DIFF
--- a/src/src/components/datasets.jsx
+++ b/src/src/components/datasets.jsx
@@ -7,7 +7,7 @@ import {useNavigate} from "react-router-dom";
 import {useLocation } from 'react-router'
 import Dialog from '@material-ui/core/Dialog';
 import DialogContent from '@material-ui/core/DialogContent';
-import Result from "./uuid/result";
+import ResultLegacy from "./uuid/result";
 import { HuBMAPContext } from "./hubmapContext";
 
 
@@ -154,7 +154,7 @@ export const RenderDataset = (props) => {
       return (
         <Dialog aria-labelledby="result-dialog" open={newVersionShow} maxWidth="xs">
         <DialogContent>
-        <Result
+        <ResultLegacy
           result={newResult}
           onReturn={onClose}
           handleCancel={handleCancel}

--- a/src/src/components/newSample.jsx
+++ b/src/src/components/newSample.jsx
@@ -690,7 +690,7 @@ export const SampleForm = (props) => {
                 <b>Source Category:</b>{" "}
                 {sourceEntity.entity_type === "Donor" ? "Donor" : toTitleCase(sourceEntity.sample_category) }
               </Typography>
-              {sourceEntity.organ && (
+              {sourceEntity.organ && !entityData.direct_ancestor?.organ &&(
                 <Typography>
                   <b>Source Organ:</b>{" "}
                   {organ_types[sourceEntity.organ]}

--- a/src/src/components/publications.jsx
+++ b/src/src/components/publications.jsx
@@ -6,12 +6,11 @@ import PublicationFormLegacy from "./ingest/publications_edit";
 import {useNavigate} from "react-router-dom";
 import { useLocation } from 'react-router'
 
-
-
 import Dialog from '@material-ui/core/Dialog';
 import DialogContent from '@material-ui/core/DialogContent';
-import Result from "./uuid/result";
+import ResultLegacy from "./uuid/result";
 
+// !!! Deprecated & succedded by newPublication.jsx
 
 /*
 title: string, required-- this overrides the title field in Dataset which is auto-calculated
@@ -33,8 +32,6 @@ pages_or_article_num, string, e.g., “23”, “23-49”, “e1003424”, not-r
 publication_status, boolean, required
   A boolean representing if the publication has been published yet or not.  (Published in the target/venue journal/proceeding/etc.. NOT published in the sense of Dataset publication)
 */
-
-
 
 
 export const RenderPublication = (props) => {
@@ -188,7 +185,7 @@ export const RenderPublication = (props) => {
       return (
         <Dialog aria-labelledby="result-dialog" open={newVersionShow} maxWidth="xs">
         <DialogContent>
-        <Result
+        <ResultLegacy
           result={newResult}
           onReturn={onClose}
           handleCancelForm={handleCancelForm}

--- a/src/src/components/ui/result.jsx
+++ b/src/src/components/ui/result.jsx
@@ -1,7 +1,7 @@
-import React, { Component } from "react";
+import React, { useState } from "react";
 import MultipleListModal from "../uuid/tissue_form_components/multipleListModal";
 import Tooltip from '@mui/material/Tooltip';
-import {Typography} from "@mui/material";
+import { Typography } from "@mui/material";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faFolder,
@@ -10,151 +10,131 @@ import {
 import Button from '@mui/material/Button';
 import Link from '@mui/material/Link';
 
-class Result extends Component {
-  state = { results: [] };
+const Result = (props) => {
 
-  handleCopyToClipboard = () => {
-    var $body = document.getElementsByTagName("body")[0];
-    var doi = document.getElementById("display_doi").innerHTML;
-
-    var $tempInput = document.createElement("INPUT");
-    $body.appendChild($tempInput);
-    $tempInput.setAttribute("value", doi);
-    $tempInput.select();
-    document.execCommand("copy");
-    $body.removeChild($tempInput);
-
-    this.setState({
-      copied: true
-    });
-
-    setTimeout(() => {
-      this.setState({ copied: null });
-    }, 5000);
-  };
-
-  handleReturnClick = e => {
+  const handleReturnClick = (e) => {
     console.debug("handleReturnClick", e);
-    if(this.props.onReturn){
-      this.props.onReturn();
-    }else{
+    if (props.onReturn) {
+      props.onReturn();
+    } else {
       console.debug();
     }
   };
 
-  render() {
-
-    return (
-      <React.Fragment> 
-
-        {(this.props.result.entity.new_samples && this.props.result.entity.new_samples.length > 1) && (
-          <MultipleListModal
-            ids={this.props.result.entity.new_samples}
-            handleCancel={this.props.handleReturnClick}/>
-        )}
-
-        {this.props.result !== undefined && (<>
-            {this.props.result.entity && ( 
-              <Typography>Save was successful</Typography>
-            )}
-            {this.props.result.entity.hubmap_id && ( 
-              <div className="portal-jss116 col-sm-12 ml-2">
-                  HuBMAP ID: <Link variant="body2" href={"/"+this.props.result.entity.entity_type.toLowerCase()+"/"+this.props.result.entity.uuid}>{this.props.result.entity.hubmap_id}</Link>
-              </div>
-            )}
-            {this.props.result.entity.submission_id && (
-              <div className="portal-jss116 col-sm-12 ml-2">
-                  Submission ID: {this.props.result.entity.submission_id}
-              </div>
-            )}
-            {this.props.result.entity.entity_type && (
-              <div className="portal-jss116 col-sm-12 ml-2">
-                  Type: {this.props.result.entity.entity_type}
-              </div>
-            )}
-            {this.props.result.globus_path && (
-              <div className="portal-jss116 col-sm-12 ml-2">
-                  <a
-                    href={this.props.result.globus_path}
-                    target='_blank'
-                    rel='noopener noreferrer'
-                  ><FontAwesomeIcon icon={faFolder} data-tip data-for='folder_tooltip'/> Click here to go to the Globus data repository</a>
-              </div>
-            )}
-            {this.props.result.entity.uuid && (
-              <div className="d-none">
-                <a
-                  href={this.props.result.entity.entity_type+"/"+this.props.result.entity.uuid}
-                ><FontAwesomeIcon icon={faLink} data-tip data-for='link_tooltip'/> View in Ingest</a>
-              </div>
-            )}
-        </>)}
-        <div className="row">
-
-          <div className="col-sm-12 mt-2 mr-2 mb-2 text-center">
-            {this.props.result !== undefined && this.props.result.entity.entity_type === "Donor" && (
-              <Tooltip 
-              placement="bottom-start" 
-              title={
-                  <React.Fragment>
-                    <Typography variant="caption" color="inherit">Registering organs from a new Donor will return with the release of the new Sample form 🎉</Typography><br />
-                    <Typography variant="caption" color="inherit">To Register an organ choose "Sample" from the "INDIVIDUAL" menu and pick this Donor's ID as the "Source ID".</Typography>
-                  </React.Fragment>
-                }>
-                <span>
-                  <Button
-                    className="btn btn-success m-2"
-                    variant="contained" 
-                    disabled
-                    color="primary"
-                    onClick={() =>
-                      this.props.onCreateNext(
-                        this.props.result.entity
-                      )
-                    }>
-                    Register an organ from this donor
-                  </Button>
-                </span>
-              </Tooltip>
-            )}
-            {/* @TODO: this likely needs to update from specimen type */}
-            { this.props.result !== undefined && this.props.result.organ && (
-                <Tooltip placement="top-start" title={"Registering tisse samples from a new organ will return with the release of the new Sample form 🎉"}>
-                  <span>
-                    <Button
-                      className="btn btn-primary m-2"
-                      variant="contained" 
-                      disabled
-                      color="success"
-                      sx={{ 
-                        marginRight: '10px',
-                      }}
-                      type="button"
-                      onClick={() =>
-                        this.props.onCreateNext(
-                          this.props.result.entity
-                        )
-                      }
-                    >
-                      Register tissue samples from this organ
-                    </Button>
-                  </span>
-                </Tooltip>
-              )}
-            <Button
-              className="btn btn-success"
-              variant="contained" 
-              color="primary"
-              size="large"
-              onClick={this.handleReturnClick}>
-              Done
-            </Button>
-            </div>
-        </div>
-            
-      </React.Fragment>
-    );
+  function renderField(label, value) {
+    return value ? (
+      <div className="portal-jss116 col-sm-12 ml-2">
+        {label}: {value}
+      </div>
+    ) : null;
   }
-}
+
+  function newSamplePreload() {
+    let thisSource = props.result.entity;
+    if(thisSource && thisSource.uuid) {
+      let newURL = `${process.env.REACT_APP_URL}/new/sample?source=${thisSource.uuid}`;
+      window.location.replace(newURL);
+    }
+  }
+
+  return (
+    <React.Fragment>
+      {(props.result.entity?.new_samples && props.result.entity.new_samples.length > 1) && (
+        <MultipleListModal
+          ids={props.result.entity.new_samples}
+          handleCancel={handleReturnClick}
+        />
+      )}
+
+      {props.result !== undefined && (
+        <>
+          {props.result.entity && (
+            <Typography>Save was successful</Typography>
+          )}
+          {props.result.entity.hubmap_id && (
+            <div className="portal-jss116 col-sm-12 ml-2">
+              HuBMAP ID: <Link variant="body2" href={"/" + props.result.entity.entity_type.toLowerCase() + "/" + props.result.entity.uuid}>{props.result.entity.hubmap_id}</Link>
+            </div>
+          )}
+          {renderField("Submission ID", props.result.entity.submission_id)}
+          {renderField("Type", props.result.entity.entity_type)}
+          {props.result.globus_path && (
+            <div className="portal-jss116 col-sm-12 ml-2">
+              <a
+                href={props.result.globus_path}
+                target='_blank'
+                rel='noopener noreferrer'
+              ><FontAwesomeIcon icon={faFolder} data-tip data-for='folder_tooltip' /> Click here to go to the Globus data repository</a>
+            </div>
+          )}
+          
+          {props.result.entity.uuid && (
+            <div className="d-none">
+              <a
+                href={props.result.entity.entity_type + "/" + props.result.entity.uuid}
+              ><FontAwesomeIcon icon={faLink} data-tip data-for='link_tooltip' /> View in Ingest</a>
+            </div>
+          )}
+        </>
+      )}
+      <div className="row">
+        <div className="col-sm-12 mt-2 mr-2 mb-2 text-center">
+          {props.result !== undefined && props.result.entity.entity_type === "Donor" && (
+            // <Tooltip
+            //   placement="bottom-start"
+            //   title={
+            //     <React.Fragment>
+            //       <Typography variant="caption" color="inherit">Registering organs from a new Donor will return with the release of the new Sample form 🎉</Typography><br />
+            //       <Typography variant="caption" color="inherit">To Register an organ choose "Sample" from the "INDIVIDUAL" menu and pick this Donor's ID as the "Source ID".</Typography>
+            //     </React.Fragment>
+            //   }>
+              <span>
+                <Button
+                  className="btn btn-success m-2"
+                  variant="contained"
+                  color="primary"
+                  onClick={(e) =>newSamplePreload(e)}>
+                  Register an organ from this donor
+                </Button>
+              </span>
+            // </Tooltip>
+          )}
+          {/* @TODO: this likely needs to update from specimen type */}
+          {props.result !== undefined && props.result.organ && (
+            <Tooltip placement="top-start" title={"Registering tisse samples from a new organ will return with the release of the new Sample form 🎉"}>
+              <span>
+                <Button
+                  className="btn btn-primary m-2"
+                  variant="contained"
+                  disabled
+                  color="success"
+                  sx={{
+                    marginRight: '10px',
+                  }}
+                  type="button"
+                  onClick={() =>
+                    props.onCreateNext(
+                      props.result.entity
+                    )
+                  }
+                >
+                  Register tissue samples from this organ
+                </Button>
+              </span>
+            </Tooltip>
+          )}
+          <Button
+            className="btn btn-success"
+            variant="contained"
+            color="primary"
+            size="large"
+            onClick={handleReturnClick}>
+            Done
+          </Button>
+        </div>
+      </div>
+    </React.Fragment>
+  );
+};
 
 export default Result;

--- a/src/src/components/ui/result.jsx
+++ b/src/src/components/ui/result.jsx
@@ -11,7 +11,7 @@ import Button from '@mui/material/Button';
 import Link from '@mui/material/Link';
 
 const Result = (props) => {
-
+  console.debug('%c◉ props ', 'color:#00ff7b', props);
   const handleReturnClick = (e) => {
     console.debug("handleReturnClick", e);
     if (props.onReturn) {
@@ -29,14 +29,14 @@ const Result = (props) => {
     ) : null;
   }
 
-  function newSamplePreload() {
+  function newSampleSourcePreload() {
     let thisSource = props.result.entity;
+    console.debug('%c◉ thisSource ', 'color:#001AFF', thisSource);
     if(thisSource && thisSource.uuid) {
-      let newURL = `${process.env.REACT_APP_URL}/new/sample?source=${thisSource.uuid}`;
+      let newURL = `${process.env.REACT_APP_URL}/new/sample?direct_ancestor_uuid=${thisSource.uuid}`;
       window.location.replace(newURL);
     }
   }
-
   return (
     <React.Fragment>
       {(props.result.entity?.new_samples && props.result.entity.new_samples.length > 1) && (
@@ -79,49 +79,18 @@ const Result = (props) => {
       )}
       <div className="row">
         <div className="col-sm-12 mt-2 mr-2 mb-2 text-center">
-          {props.result !== undefined && props.result.entity.entity_type === "Donor" && (
-            // <Tooltip
-            //   placement="bottom-start"
-            //   title={
-            //     <React.Fragment>
-            //       <Typography variant="caption" color="inherit">Registering organs from a new Donor will return with the release of the new Sample form 🎉</Typography><br />
-            //       <Typography variant="caption" color="inherit">To Register an organ choose "Sample" from the "INDIVIDUAL" menu and pick this Donor's ID as the "Source ID".</Typography>
-            //     </React.Fragment>
-            //   }>
-              <span>
-                <Button
-                  className="btn btn-success m-2"
-                  variant="contained"
-                  color="primary"
-                  onClick={(e) =>newSamplePreload(e)}>
-                  Register an organ from this donor
-                </Button>
-              </span>
-            // </Tooltip>
-          )}
-          {/* @TODO: this likely needs to update from specimen type */}
-          {props.result !== undefined && props.result.organ && (
-            <Tooltip placement="top-start" title={"Registering tisse samples from a new organ will return with the release of the new Sample form 🎉"}>
-              <span>
-                <Button
-                  className="btn btn-primary m-2"
-                  variant="contained"
-                  disabled
-                  color="success"
-                  sx={{
-                    marginRight: '10px',
-                  }}
-                  type="button"
-                  onClick={() =>
-                    props.onCreateNext(
-                      props.result.entity
-                    )
-                  }
-                >
-                  Register tissue samples from this organ
-                </Button>
-              </span>
-            </Tooltip>
+          {props.result !== undefined && (props.result.entity.entity_type === "Donor" || props.result.entity.sample_category === "organ" ) && (
+            <span>
+              <Button
+                className="btn btn-success m-2"
+                variant="contained"
+                color="primary"
+                onClick={(e) =>newSampleSourcePreload(e)}>
+                  {props.result.entity.entity_type === "Donor" 
+                    ? "Register an Organ from this Donor" 
+                    : "Register a new Sample from this Organ"}
+              </Button>
+            </span>
           )}
           <Button
             className="btn btn-success"

--- a/src/src/components/uuid/forms.jsx
+++ b/src/src/components/uuid/forms.jsx
@@ -8,7 +8,7 @@ import { toTitleCase } from "../../utils/string_helper";
 import DonorForm from "./donor_form_components/donorForm";
 import TissueForm from "./tissue_form_components/tissueForm";
 import DatasetEdit from "../ingest/dataset_edit";
-import Result from "./result";
+import ResultLegacy from "./result";
 // import NewDatasetModal from "../../ingest/newDatasetModal";
 import NewDatasetModal from "../ingest/newDatasetModal";
 import PublicationEdit from '../ingest/publications_edit';
@@ -170,7 +170,7 @@ class Forms extends Component {
       return (
         <Dialog aria-labelledby="result-dialog" open={this.state.showSuccessDialog} maxWidth={this.state.result_dialog_size}>
         <DialogContent>
-        <Result
+        <ResultLegacy
           result={this.state.result}
           onReturn={this.props.onReturn}
           handleCancel={this.props.handleCancel}
@@ -181,14 +181,14 @@ class Forms extends Component {
         </Dialog>
       );
     }
-    if (this.state.formType === "donor") {
+    if (this.state.formType === "donor") { // Deprecated, Form Upgraded
       return (       
         <DonorForm
           onCreated={this.onCreated}
           handleCancel={this.props.handleCancel}
         />
       );
-    } else if (this.state.formType === "sample") {
+    } else if (this.state.formType === "sample") { // Deprecated, Form Upgraded
       return (
         <TissueForm
           onCreated={this.onCreated}
@@ -218,7 +218,7 @@ class Forms extends Component {
           />
           
         )
-    } else if (this.props.formType === "publication"  ) {
+    } else if (this.props.formType === "publication"  ) { // Deprecated, Form Upgraded
       
       
         return (

--- a/src/src/components/uuid/result.jsx
+++ b/src/src/components/uuid/result.jsx
@@ -9,7 +9,7 @@ import {
 import Button from '@mui/material/Button';
 import Link from '@mui/material/Link';
 
-class Result extends Component {
+class ResultLegacy extends Component {
   state = { results: [] };
 
   handleCopyToClipboard = () => {

--- a/src/src/components/uuid/result.jsx
+++ b/src/src/components/uuid/result.jsx
@@ -163,4 +163,4 @@ class ResultLegacy extends Component {
   }
 }
 
-export default Result;
+export default ResultLegacy;


### PR DESCRIPTION
Re-Enables the Create Organ from Donor` and `Create Sample from Organ` buttons post-registration for Donors and Samples
Adds small detail in the disables RUI message if required Donor Metadata is missing (sex)
Allows Sample form fields to be populated by URL params