### PR TITLE
Prevents Admin from Modifying Fields on Retracted entities

### DIFF
--- a/src/src/components/forms/Datasets.jsx
+++ b/src/src/components/forms/Datasets.jsx
@@ -180,6 +180,11 @@ export const DatasetForm = (props) => {
                     setReadOnlySources(true);
                   }
                   setPermissions(response.results);
+                  // Even if we're an admin,if the entity's been retracted then No Edits.
+                  // Period.
+                  if (entityData.status.toLowerCase() === "retracted") {
+                    setPermissions(prevVals => ({ ...prevVals, has_write_priv: false }));
+                  }
                 })
                 .catch((error) => {
                   // console.error(error);

--- a/src/src/components/forms/Publications.jsx
+++ b/src/src/components/forms/Publications.jsx
@@ -131,6 +131,11 @@ export const PublicationForm = (props) => {
                     });
                   }
                   setPermissions(response.results);
+                    // Even if we're an admin,if the entity's been retracted then No Edits.
+                    // Period.
+                    if (entityData.status.toLowerCase() === "retracted") {
+                      setPermissions(prevVals => ({ ...prevVals, has_write_priv: false }));
+                    }
                 })
                 .catch((error) => {
                   setPageErrors(error);


### PR DESCRIPTION
Prevents Admin from Modifying Fields on Retracted entities (previously Admin incorrectly could while users correctly could not)
Addresses #1935 