### PR TITLE
adjust gateway handling for Service Outage messaging

### DIFF
--- a/src/src/App.jsx
+++ b/src/src/App.jsx
@@ -166,9 +166,7 @@ export function App(){
           }
         }
       })
-      .catch((error) => {
-        console.error('gateway_api_status ERROR', error);
-      });
+      .catch(() => {});
 
     var loadCounter = 0;
     let url = new URL(window.location.href);

--- a/src/src/service/gateway_service.js
+++ b/src/src/service/gateway_service.js
@@ -1,23 +1,35 @@
 
 import axios from "axios";
 
+export function gatewayServiceHealth(data = {}) {
+  const connectionHealth = (value) => {
+    if (value === true || value === false) {
+      return value;
+    }
+    return undefined;
+  };
+  const elasticsearchStatus = data.search_api?.elasticsearch_status;
+
+  return {
+    entity_api: connectionHealth(data.entity_api?.neo4j_connection),
+    ingest_api: connectionHealth(data.ingest_api?.neo4j_connection),
+    ontology_api: connectionHealth(data.ontology_api?.neo4j_connection),
+    search_api: elasticsearchStatus === "red"
+      ? false
+      : ["green", "yellow"].includes(elasticsearchStatus)
+        ? true
+        : undefined,
+  };
+}
+
 export function gateway_api_status() { 
   return axios
     .get(`https://gateway.api.hubmapconsortium.org/status.json`)
       .then(res => {
         console.debug("gateway_api_status RES", res.status, res.data);
-        const d = res.data || {};
-        let services = {
-          entity_api: Boolean(d.entity_api?.neo4j_connection),
-          ingest_api: Boolean(d.ingest_api?.neo4j_connection),
-          ontology_api: Boolean(d.ontology_api?.neo4j_connection),
-          search_api: d.search_api?.elasticsearch_status === "green"
-        }
-        return {status: res.status, results: services};
+        return {status: res.status, results: gatewayServiceHealth(res.data)};
       })
       .catch(error => {
-        console.error("gateway_api_status ERROR", error);
         return {status: error.response ? error.response.status : 500, results: null}
       });
 }
-

--- a/src/src/tests/service/gatewayService.test.js
+++ b/src/src/tests/service/gatewayService.test.js
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { gatewayServiceHealth } from "../../service/gateway_service";
+
+describe("gateway service health", () => {
+  it("preserves missing service results as unknown", () => {
+    expect(gatewayServiceHealth({})).toEqual({
+      entity_api: undefined,
+      ingest_api: undefined,
+      ontology_api: undefined,
+      search_api: undefined,
+    });
+  });
+
+  it("reports only explicit unhealthy service values as down", () => {
+    expect(gatewayServiceHealth({
+      entity_api: { neo4j_connection: false },
+      ingest_api: { neo4j_connection: true },
+      search_api: { elasticsearch_status: "red" },
+    })).toEqual({
+      entity_api: false,
+      ingest_api: true,
+      ontology_api: undefined,
+      search_api: false,
+    });
+  });
+
+  it("does not treat a degraded Elasticsearch response as down", () => {
+    expect(gatewayServiceHealth({
+      search_api: { elasticsearch_status: "yellow" },
+    }).search_api).toBe(true);
+  });
+});


### PR DESCRIPTION
adjust gateway handling to utilize Service Outage messaging only when json is fully resolved & contains reported errors (no more rendering on network failure)